### PR TITLE
Bump cursive to 0.15 to avoid yanked enum-map version

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -37,7 +37,7 @@ maplit = "1.0.1"
 env_logger = "0.7.1"
 serde_json = { version = "1.0.73", features = ["preserve_order"] } # for deterministic JSON testing
 spectral = "0.6.0"
-cursive = "0.11"
+cursive = "0.15"
 tokio = { version = "1.2.0", features = ["macros", "time"] }
 test-case = "1.2.0"
 mockito = "0.30.0"

--- a/launchdarkly-server-sdk/examples/progress_ncurses.rs
+++ b/launchdarkly-server-sdk/examples/progress_ncurses.rs
@@ -11,7 +11,7 @@ use launchdarkly_server_sdk::{Client, ConfigBuilder, ServiceEndpointsBuilder, Us
 use cursive::traits::Boxable;
 use cursive::utils::Counter;
 use cursive::views::{Dialog, ProgressBar};
-use cursive::Cursive;
+use cursive::{Cursive, CursiveExt};
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
**Requirements**

- [] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Running `cargo check` on a fresh repository checkout fails with the following error:
```
error: failed to select a version for the requirement `enum-map = "^0.5.0"`
candidate versions found which didn't match: 2.0.1, 2.0.0, 1.1.1, ...
location searched: crates.io index
required by package `cursive v0.11.0`
    ... which satisfies dependency `cursive = "^0.11"` of package `launchdarkly-server-sdk v1.0.0-beta.2 (launchdarkly-rust-server-sdk/launchdarkly-server-sdk)`
    ... which satisfies path dependency `launchdarkly-server-sdk` (locked to 1.0.0-beta.2) of package `contract-tests v0.1.0 (launchdarkly-rust-server-sdk/contract-tests)`
```

This is caused by `enum-map` 0.5 being [yanked](https://crates.io/crates/enum-map/0.5.0) from crates.io. This PR bumps `cursive` to 0.15, which depends on a non-yanked version of `enum-map`.

**Describe alternatives you've considered**

Bumping to the latest version of `cursive` (0.17.0) introduces a bunch of breaking changes that would require a more significant revision of the `progress_ncurses` example.
