### PR TITLE
Bump reqwest to 0.11

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.12"
 lazy_static = "1.4.0"
 log = "0.4.14"
 lru = { version = "0.5.3", default_features = false }
-reqwest = { version = "0.9.11", default_features = false, features = ["rustls"] }
+reqwest = { version = "0.11", default_features = false, features = ["blocking", "json", "rustls-tls"] }
 ring = "0.16.20"
 launchdarkly-server-sdk-evaluation = { version = "1.0.0-beta.2" }
 serde = { version = "1.0.132", features = ["derive"] }

--- a/launchdarkly-server-sdk/src/events/processor_builders.rs
+++ b/launchdarkly-server-sdk/src/events/processor_builders.rs
@@ -79,7 +79,7 @@ impl EventProcessorFactory for EventProcessorBuilder {
             BuildError::InvalidConfig(format!("couldn't parse events_base_url: {}", e))
         })?;
 
-        let http = reqwest::Client::builder().build().map_err(|e| {
+        let http = reqwest::blocking::Client::builder().build().map_err(|e| {
             BuildError::InvalidConfig(format!("unable to build reqwest client: {}", e))
         })?;
 

--- a/launchdarkly-server-sdk/src/events/sender.rs
+++ b/launchdarkly-server-sdk/src/events/sender.rs
@@ -2,7 +2,8 @@ use crate::reqwest::is_http_error_recoverable;
 use crossbeam_channel::Sender;
 
 use chrono::DateTime;
-use r::{header::HeaderValue, Response};
+use r::blocking::Response;
+use r::header::HeaderValue;
 use reqwest as r;
 
 use super::event::OutputEvent;
@@ -21,11 +22,11 @@ pub trait EventSender: Send + Sync {
 pub struct ReqwestEventSender {
     url: r::Url,
     sdk_key: String,
-    http: r::Client,
+    http: r::blocking::Client,
 }
 
 impl ReqwestEventSender {
-    pub fn new(http: r::Client, url: r::Url, sdk_key: &str) -> Self {
+    pub fn new(http: r::blocking::Client, url: r::Url, sdk_key: &str) -> Self {
         Self {
             http,
             url,

--- a/launchdarkly-server-sdk/src/feature_requester.rs
+++ b/launchdarkly-server-sdk/src/feature_requester.rs
@@ -22,14 +22,14 @@ pub trait FeatureRequester: Send {
 }
 
 pub struct ReqwestFeatureRequester {
-    http: r::Client,
+    http: r::blocking::Client,
     url: r::Url,
     sdk_key: String,
     cache: Option<CachedEntry>,
 }
 
 impl ReqwestFeatureRequester {
-    pub fn new(http: r::Client, url: r::Url, sdk_key: String) -> Self {
+    pub fn new(http: r::blocking::Client, url: r::Url, sdk_key: String) -> Self {
         Self {
             http,
             url,
@@ -54,7 +54,7 @@ impl FeatureRequester for ReqwestFeatureRequester {
 
         let resp = request_builder.send();
 
-        let mut response = match resp {
+        let response = match resp {
             Ok(response) => response,
             Err(e) => {
                 error!("An error occurred while retrieving flag information: {}", e);

--- a/launchdarkly-server-sdk/src/feature_requester_builders.rs
+++ b/launchdarkly-server-sdk/src/feature_requester_builders.rs
@@ -41,7 +41,7 @@ impl FeatureRequesterFactory for ReqwestFeatureRequesterBuilder {
             .map_err(|_| BuildError::InvalidConfig("Invalid base url provided".into()))?;
         url.set_path("/sdk/latest-all");
 
-        let http = r::Client::builder()
+        let http = r::blocking::Client::builder()
             .build()
             .map_err(|e| BuildError::InvalidConfig(e.to_string()))?;
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This PR upgrades `reqwest` from 0.9 (~2 years old) to the latest major release 0.11. The new version supports async requests using Rust futures and pulls in lots of improvements from rustls and other packages.

For some reason, the old version of reqwest fails to report analytics events to Launchdarkly. I see the following error in the logs:
```
TRACE hyper::client::pool            2022-02-16 01:59:15.915612675+00:00 reqwest-internal-syn - checkout waiting for idle connection: "https://events.launchdarkly.com"
TRACE hyper::client::connect::http   2022-02-16 01:59:15.915625259+00:00 reqwest-internal-syn - Http::connect; scheme=https, host=events.launchdarkly.com, port=None
TRACE hyper::client::pool            2022-02-16 01:59:15.915641509+00:00 reqwest-internal-syn - checkout dropped for "https://events.launchdarkly.com"
ERROR launchdarkly_server_sdk::event 2022-02-16 01:59:15.915659300+00:00              unnamed - Failed to send events. Some events were dropped: Error(Hyper(Error(Connect, Custom { kind: InvalidInput, error: NotHttp })), "https://events.launchdarkly.com/bulk")
```

The error occurs while `hyper` is trying to connect to `https://events.launchdarkly.com`, and the `NotHttp` error makes me think that this is related to the old version of `rustls` being used by the old version of `reqwest`. After applying this PR, I'm able to see the users correctly registered in the Launchdarkly UI and a successful response in the logs:
```
DEBUG reqwest::async_impl::client    2022-02-16 02:50:37.672525754+00:00 reqwest-internal-syn - response '202 Accepted' for https://events.launchdarkly.com/bulk
```

**Describe alternatives you've considered**

In addition to upgrading `reqwest`, I recommend rewriting the code to use the non-blocking async `reqwest::Client`. In this PR, I've maintained the existing blocking approach. However, this is incompatible with the `tokio` single-threaded runtime that others may be using, and using threads in general is more expensive than using non-blocking Rust futures.
