### PR TITLE
Bump lru to fix RUSTSEC-2021-0130 vulnerability

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -20,7 +20,7 @@ eventsource-client = "0.8.1"
 futures = "0.3.12"
 lazy_static = "1.4.0"
 log = "0.4.14"
-lru = { version = "0.5.3", default_features = false }
+lru = { version = "0.7.2", default_features = false }
 reqwest = { version = "0.9.11", default_features = false, features = ["rustls"] }
 ring = "0.16.20"
 launchdarkly-server-sdk-evaluation = { version = "1.0.0-beta.2" }


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

None

**Describe the solution you've provided**

This PR bumps `lru` to address https://rustsec.org/advisories/RUSTSEC-2021-0130, which is fixed beginning in 0.7.2.

**Describe alternatives you've considered**

None
