### PR TITLE
add support for arbitrary connectors to StreamingDataSourceBuilder

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -32,6 +32,7 @@ threadpool = "1.8.1"
 parking_lot = "0.12.0"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 moka = "0.7.1"
+hyper = { version = "0.14.17", features = ["client"] }
 
 [dev-dependencies]
 maplit = "1.0.1"

--- a/launchdarkly-server-sdk/examples/connector.rs
+++ b/launchdarkly-server-sdk/examples/connector.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate maplit;
+
+use std::env;
+
+use eventsource_client::HttpsConnector;
+use launchdarkly_server_sdk::{
+    Client, ConfigBuilder, ServiceEndpointsBuilder, StreamingDataSourceBuilder, User,
+};
+
+use env_logger::Env;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init_from_env(Env::new().default_filter_or("info"));
+
+    let sdk_key = env::var("LAUNCHDARKLY_SDK_KEY").expect("Please set LAUNCHDARKLY_SDK_KEY");
+    let mut data_source = StreamingDataSourceBuilder::new();
+    data_source.https_connector(HttpsConnector::with_native_roots());
+    let config = ConfigBuilder::new(&sdk_key)
+        .data_source(&data_source)
+        .build();
+    let client = Client::build(config).expect("failed to start client");
+}

--- a/launchdarkly-server-sdk/src/config.rs
+++ b/launchdarkly-server-sdk/src/config.rs
@@ -1,3 +1,5 @@
+use eventsource_client::HttpsConnector;
+
 use crate::data_source_builders::{DataSourceFactory, NullDataSourceBuilder};
 use crate::events::processor_builders::{
     EventProcessorBuilder, EventProcessorFactory, NullEventProcessorBuilder,
@@ -256,7 +258,7 @@ impl ConfigBuilder {
                 warn!("Custom data source builders will be ignored when in offline mode");
                 Box::new(NullDataSourceBuilder::new())
             }
-            None => Box::new(StreamingDataSourceBuilder::new()),
+            None => Box::new(StreamingDataSourceBuilder::<HttpsConnector>::new()),
             Some(_data_source_builder) => self.data_source_builder.unwrap(),
         };
 

--- a/launchdarkly-server-sdk/src/data_source_builders.rs
+++ b/launchdarkly-server-sdk/src/data_source_builders.rs
@@ -1,10 +1,13 @@
 use super::service_endpoints;
 use crate::data_source::{DataSource, NullDataSource, PollingDataSource, StreamingDataSource};
 use crate::feature_requester_builders::{FeatureRequesterFactory, ReqwestFeatureRequesterBuilder};
-use eventsource_client::HttpsConnector;
+use hyper::client::connect::Connection;
+use hyper::service::Service;
+use hyper::Uri;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(test)]
 use super::data_source;
@@ -45,18 +48,19 @@ pub trait DataSourceFactory {
 /// ```
 /// # use launchdarkly_server_sdk::{StreamingDataSourceBuilder, ConfigBuilder};
 /// # use std::time::Duration;
+/// # use eventsource_client::HttpsConnector;
 /// # fn main() {
-///     ConfigBuilder::new("sdk-key").data_source(StreamingDataSourceBuilder::new()
+///     ConfigBuilder::new("sdk-key").data_source(StreamingDataSourceBuilder::<HttpsConnector>::new()
 ///         .initial_reconnect_delay(Duration::from_secs(10)));
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct StreamingDataSourceBuilder {
+pub struct StreamingDataSourceBuilder<C> {
     initial_reconnect_delay: Duration,
-    connector: Option<HttpsConnector>,
+    connector: Option<C>,
 }
 
-impl StreamingDataSourceBuilder {
+impl<C> StreamingDataSourceBuilder<C> {
     /// Create a new instance of the [StreamingDataSourceBuilder] with default values.
     pub fn new() -> Self {
         Self {
@@ -76,13 +80,19 @@ impl StreamingDataSourceBuilder {
     /// multiple client instances. This is especially useful for the `sdk-test-harness`
     /// where many client instances are created throughout the test and reading
     /// the native certificates is a substantial portion of the runtime.
-    pub fn https_connector(&mut self, connector: HttpsConnector) -> &mut Self {
+    pub fn https_connector(&mut self, connector: C) -> &mut Self {
         self.connector = Some(connector);
         self
     }
 }
 
-impl DataSourceFactory for StreamingDataSourceBuilder {
+impl<C> DataSourceFactory for StreamingDataSourceBuilder<C>
+where
+    C: Service<Uri> + Clone + Send + Sync + 'static,
+    C::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin,
+    C::Future: Send + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
     fn build(
         &self,
         endpoints: &service_endpoints::ServiceEndpoints,
@@ -113,7 +123,7 @@ impl DataSourceFactory for StreamingDataSourceBuilder {
     }
 }
 
-impl Default for StreamingDataSourceBuilder {
+impl<C> Default for StreamingDataSourceBuilder<C> {
     fn default() -> Self {
         StreamingDataSourceBuilder::new()
     }
@@ -305,11 +315,44 @@ mod tests {
 
     #[test]
     fn default_stream_builder_has_correct_defaults() {
-        let builder = StreamingDataSourceBuilder::new();
+        let builder = StreamingDataSourceBuilder::<eventsource_client::HttpsConnector>::new();
         assert_eq!(
             builder.initial_reconnect_delay,
             DEFAULT_INITIAL_RECONNECT_DELAY
         );
+    }
+
+    #[test]
+    fn stream_builder_can_use_custom_connector() {
+        #[derive(Debug, Clone)]
+        struct TestConnector;
+        impl hyper::service::Service<hyper::Uri> for TestConnector {
+            type Response = tokio::net::TcpStream;
+            type Error = std::io::Error;
+            type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(
+                &mut self,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: hyper::Uri) -> Self::Future {
+                // this won't be called during the test
+                unreachable!();
+            }
+        }
+
+        let mut builder = StreamingDataSourceBuilder::new();
+        builder.https_connector(TestConnector);
+        assert!(builder
+            .build(
+                &crate::ServiceEndpointsBuilder::new().build().unwrap(),
+                "test",
+                None
+            )
+            .is_ok());
     }
 
     #[test]
@@ -320,7 +363,7 @@ mod tests {
 
     #[test]
     fn initial_reconnect_delay_for_streaming_can_be_adjusted() {
-        let mut builder = StreamingDataSourceBuilder::new();
+        let mut builder = StreamingDataSourceBuilder::<()>::new();
         builder.initial_reconnect_delay(Duration::from_secs(1234));
         assert_eq!(builder.initial_reconnect_delay, Duration::from_secs(1234));
     }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This PR adds support for using an arbitrary hyper connector with `StreamingDataSourceBuilder`. This is needed in order to use this crate with a unix socket, i.e. through [hyperlocal](https://github.com/softprops/hyperlocal).

**Describe alternatives you've considered**

This is a breaking change due to the new generic type parameter on `StreamingDataSourceBuilder`. To avoid this, a new struct implementing `DataSourceFactory` could be added (e.g. `StreamingDataSourceBuilderWithConnector`).

Alternatively, the `DataSourceFactory` trait (and ideally the `StreamingDataSource` struct) could be made part of the public API, allowing a custom connector to be used with an implementation of that trait.
