### PR TITLE
Add `hypertls` and `rustls` profiles and update dependencies

### DIFF
--- a/contract-tests/Cargo.toml
+++ b/contract-tests/Cargo.toml
@@ -14,4 +14,9 @@ launchdarkly-server-sdk = { path = "../launchdarkly-server-sdk/" }
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"
 futures = "0.3.12"
-eventsource-client = "0.11.0"
+eventsource-client = { git = "https://github.com/MaterializeInc/rust-eventsource-client", default_features = false }
+
+[features]
+default = ["rustls"]
+rustls = ["eventsource-client/rustls"]
+hypertls = ["eventsource-client/hypertls"]

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-chrono = "0.4.19"
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
 eventsource-client = "0.11.0"

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
-eventsource-client = "0.11.0"
+eventsource-client = { git = "https://github.com/MaterializeInc/rust-eventsource-client", default_features = false }
 futures = "0.3.12"
 lazy_static = "1.4.0"
 log = "0.4.14"
@@ -33,7 +33,8 @@ tokio-stream = { version = "0.1.8", features = ["sync"] }
 moka = { version = "0.9.6", default_features = false, features = ["sync", "atomic64"] } # do not pull quanta
 uuid = {version = "1.2.2", features = ["v4"] }
 hyper = { version = "0.14.17", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.23.1" , features = ["http1", "http2"]}
+hyper-rustls = { version = "0.23.1", features = ["http1", "http2"], optional = true }
+hyper-tls = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 maplit = "1.0.1"
@@ -52,3 +53,8 @@ name = "progress"
 
 [build-dependencies]
 built = "0.5.1"
+
+[features]
+default = ["rustls"]
+rustls = ["hyper-rustls", "eventsource-client/rustls"]
+hypertls = ["hyper-tls", "eventsource-client/hypertls"]

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0"
 tokio = { version = "1.2.0", features = ["rt-multi-thread"] }
 parking_lot = "0.12.0"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
-moka = "0.9.6"
+moka = { version = "0.9.6", default_features = false, features = ["sync", "atomic64"] } # do not pull quanta
 uuid = {version = "1.2.2", features = ["v4"] }
 hyper = { version = "0.14.17", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.23.1" , features = ["http1", "http2"]}

--- a/launchdarkly-server-sdk/src/feature_requester_builders.rs
+++ b/launchdarkly-server-sdk/src/feature_requester_builders.rs
@@ -1,6 +1,10 @@
 use crate::feature_requester::{FeatureRequester, HyperFeatureRequester};
 use crate::LAUNCHDARKLY_TAGS_HEADER;
+
+#[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnectorBuilder;
+#[cfg(all(feature = "hypertls", not(feature = "rustls")))]
+use hyper_tls::HttpsConnector;
 use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
@@ -43,12 +47,16 @@ impl FeatureRequesterFactory for HyperFeatureRequesterBuilder {
 
         let builder = hyper::Client::builder();
 
+        #[cfg(feature = "rustls")]
         let connector = HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_or_http()
             .enable_http1()
             .enable_http2()
             .build();
+
+        #[cfg(all(feature = "hypertls", not(feature = "rustls")))]
+        let connector = HttpsConnector::new();
 
         let http = builder.build(connector);
 


### PR DESCRIPTION
A PR with some changes that I would like to contribute after launchdarkly/rust-eventsource-client#43 lands.

**Requirements**

- [x] I have added test coverage for new or changed functionality. I am having trouble adjusting the `polling_source_passes_along_tags_header` test, though.
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
Note that launchdarkly/rust-eventsource-client#43 is a prerequisite for this PR.

**Describe the solution you've provided**

- The first two commits fix that reduces dependency declarations (306 > 295) and `*.rlib` size (16000 > 15676 bytes).
  - `chrono` has some weird structure where the standard set of features (`std`) is not the default.
  - `moka` has a similar setup with an explicit `std` feature set.
- The third commit introduces the profiles from the PR title. I've used feature flags to add two new profiles - `rustls` and `hypertls` (the former is the default and is also preferred if both are present) in order to expose `hyper-tls` as an alternative HTTPS provider.

**Describe alternatives you've considered**

N/A, we need these dependencies to be up to date and `hyper-tls` instead of `hyper-rustls` in order to integrate the Rust SDK into [MaterializeInc/materialize](https://github.com/MaterializeInc/materialize).

**Additional context**

N/A