### PR TITLE
ci: Fix failing tests

### DIFF
--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -391,14 +391,15 @@ mod tests {
         tag: Option<String>,
         matcher: impl Into<Matcher>,
     ) {
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/all")
             .with_status(200)
             .with_body("event:one\ndata:One\n\n")
             .expect_at_least(1)
             .match_header(LAUNCHDARKLY_TAGS_HEADER, matcher)
-            .create();
+            .create_async()
+            .await;
 
         let (shutdown_tx, _) = broadcast::channel::<()>(1);
         let initialized = Arc::new(AtomicBool::new(false));
@@ -446,14 +447,15 @@ mod tests {
         tag: Option<String>,
         matcher: impl Into<Matcher>,
     ) {
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/sdk/latest-all")
             .with_status(200)
             .with_body("{}")
             .expect_at_least(1)
             .match_header(LAUNCHDARKLY_TAGS_HEADER, matcher)
-            .create();
+            .create_async()
+            .await;
 
         let (shutdown_tx, _) = broadcast::channel::<()>(1);
         let initialized = Arc::new(AtomicBool::new(false));

--- a/launchdarkly-server-sdk/src/events/sender.rs
+++ b/launchdarkly-server-sdk/src/events/sender.rs
@@ -239,12 +239,13 @@ mod tests {
 
     #[tokio::test]
     async fn can_parse_server_time_from_response() {
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         server
             .mock("POST", "/bulk")
             .with_status(200)
             .with_header("date", "Fri, 13 Feb 2009 23:31:30 GMT")
-            .create();
+            .create_async()
+            .await;
 
         let (tx, rx) = bounded::<EventSenderResult>(5);
         let event_sender = build_event_sender(server.url());
@@ -259,8 +260,12 @@ mod tests {
 
     #[tokio::test]
     async fn unrecoverable_failure_requires_shutdown() {
-        let mut server = mockito::Server::new();
-        server.mock("POST", "/bulk").with_status(401).create();
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/bulk")
+            .with_status(401)
+            .create_async()
+            .await;
 
         let (tx, rx) = bounded::<EventSenderResult>(5);
         let event_sender = build_event_sender(server.url());
@@ -274,12 +279,13 @@ mod tests {
 
     #[tokio::test]
     async fn recoverable_failures_are_attempted_multiple_times() {
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("POST", "/bulk")
             .with_status(400)
             .expect(2)
-            .create();
+            .create_async()
+            .await;
 
         let (tx, rx) = bounded::<EventSenderResult>(5);
         let event_sender = build_event_sender(server.url());
@@ -294,13 +300,18 @@ mod tests {
 
     #[tokio::test]
     async fn retrying_requests_can_eventually_succeed() {
-        let mut server = mockito::Server::new();
-        server.mock("POST", "/bulk").with_status(400).create();
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/bulk")
+            .with_status(400)
+            .create_async()
+            .await;
         server
             .mock("POST", "/bulk")
             .with_status(200)
             .with_header("date", "Fri, 13 Feb 2009 23:31:30 GMT")
-            .create();
+            .create_async()
+            .await;
 
         let (tx, rx) = bounded::<EventSenderResult>(5);
         let event_sender = build_event_sender(server.url());

--- a/launchdarkly-server-sdk/src/feature_requester.rs
+++ b/launchdarkly-server-sdk/src/feature_requester.rs
@@ -149,27 +149,30 @@ mod tests {
 
     #[tokio::test]
     async fn updates_etag_as_appropriate() {
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         server
             .mock("GET", "/")
             .with_status(200)
             .with_header("etag", "INITIAL-TAG")
             .with_body(r#"{"flags": {}, "segments": {}}"#)
             .expect(1)
-            .create();
+            .create_async()
+            .await;
         server
             .mock("GET", "/")
             .with_status(304)
             .match_header("If-None-Match", "INITIAL-TAG")
             .expect(1)
-            .create();
+            .create_async()
+            .await;
         server
             .mock("GET", "/")
             .with_status(200)
             .match_header("If-None-Match", "INITIAL-TAG")
             .with_header("etag", "UPDATED-TAG")
             .with_body(r#"{"flags": {}, "segments": {}}"#)
-            .create();
+            .create_async()
+            .await;
 
         let mut requester = build_feature_requester(server.url());
         let result = requester.get_all().await;
@@ -199,13 +202,14 @@ mod tests {
         let payload =
             String::from_utf8(payload).expect("Invalid UTF-8 characters in polling payload");
 
-        let mut server = mockito::Server::new();
+        let mut server = mockito::Server::new_async().await;
         server
             .mock("GET", "/")
             .with_status(200)
             .with_body(payload)
             .expect(1)
-            .create();
+            .create_async()
+            .await;
 
         let mut requester = build_feature_requester(server.url());
         let result = requester.get_all().await;
@@ -225,8 +229,12 @@ mod tests {
         status: usize,
         error: FeatureRequesterError,
     ) {
-        let mut server = mockito::Server::new();
-        server.mock("GET", "/").with_status(status).create();
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/")
+            .with_status(status)
+            .create_async()
+            .await;
 
         let mut requester = build_feature_requester(server.url());
         let result = requester.get_all().await;


### PR DESCRIPTION
mockito made some changes in the v1.3.1 release which are effecting our
unit tests. Using their sync client within an async test was never a
supported use case, so I've updated the code to use the appropriate
async methods.
