### PR TITLE
feat: Add wait_for_initialization with timeout parameter

### DIFF
--- a/contract-tests/src/client_entity.rs
+++ b/contract-tests/src/client_entity.rs
@@ -128,7 +128,7 @@ impl ClientEntity {
         let config = config_builder.build()?;
         let client = Client::build(config)?;
         client.start_with_default_executor();
-        client.initialized_async().await;
+        client.wait_for_initialization(Duration::from_secs(5)).await;
 
         Ok(Self { client })
     }

--- a/launchdarkly-server-sdk/examples/print_flags.rs
+++ b/launchdarkly-server-sdk/examples/print_flags.rs
@@ -79,7 +79,10 @@ async fn main() {
 
     let mut interval = time::interval(Duration::from_secs(5));
 
-    let initialized = client.initialized_async().await;
+    let initialized = client
+        .wait_for_initialization(Duration::from_secs(5))
+        .await
+        .unwrap_or(false); // A timeout (None) can be treated as initialization failure
 
     if !initialized {
         error!("The client failed to initialize!");

--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -285,11 +285,9 @@ impl Client {
     /// return a boolean indicating whether or not the SDK has successfully initialized.
     pub async fn wait_for_initialization(&self, timeout: Duration) -> Option<bool> {
         if timeout > Duration::from_secs(60) {
-            warn!("wait_for_initialization was configured to block for up to {} seconds. We recommend blocking no longer than 60.", timeout.as_secs());
+            warn!("wait_for_initialization was configured to block for up to {} seconds. We recommend blocking no longer than 60 seconds.", timeout.as_secs());
         }
-        // We need o try initialized_async and also start a timer that figures after timeout.
-        // If the timer figures, I want to return None. Otherwise, we should return the result of
-        // initialized_async.
+
         let initialized = tokio::time::timeout(timeout, self.initialized_async_internal()).await;
         match initialized {
             Ok(result) => Some(result),


### PR DESCRIPTION
This method serves as a replacement for the `initialized_async` method, which has now been deprecated. LaunchDarkly does not recommend blocking an application indefinitely, and so we are working to remove methods that suggest this behavior.