### PR TITLE
chore: Bump eventsource client

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 chrono = "0.4.19"
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
-eventsource-client = { version = "0.12.2", default-features = false }
+eventsource-client = { version = "0.13.0", default-features = false }
 futures = "0.3.12"
 lazy_static = "1.4.0"
 log = "0.4.14"


### PR DESCRIPTION
This new version of the client potentially exposes some additional
connection information. We don't need it for the SDK at this point, but
it's good to keep these two repositories in sync.
