### PR TITLE
feat: support prerequisite relation data in all_flags_detail

### DIFF
--- a/contract-tests/src/main.rs
+++ b/contract-tests/src/main.rs
@@ -109,6 +109,7 @@ async fn status() -> impl Responder {
             "omit-anonymous-contexts".to_string(),
             "migrations".to_string(),
             "event-sampling".to_string(),
+            "client-prereq-events".to_string(),
         ],
     })
 }

--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -845,7 +845,7 @@ mod tests {
     use hyper::client::HttpConnector;
     use launchdarkly_server_sdk_evaluation::Reason;
     use std::collections::HashMap;
-
+    use assert_json_diff::assert_json_eq;
     use tokio::time::Instant;
 
     use crate::data_source::MockDataSource;
@@ -854,10 +854,7 @@ mod tests {
     use crate::events::event::{OutputEvent, VariationKey};
     use crate::events::processor_builders::EventProcessorBuilder;
     use crate::stores::store_types::{PatchTarget, StorageItem};
-    use crate::test_common::{
-        self, basic_flag, basic_flag_with_prereq, basic_int_flag, basic_migration_flag,
-        basic_off_flag,
-    };
+    use crate::test_common::{self, basic_flag, basic_flag_with_prereq, basic_flag_with_prereqs_and_visibility, basic_flag_with_visibility, basic_int_flag, basic_migration_flag, basic_off_flag};
     use crate::{ConfigBuilder, MigratorBuilder, Operation, Origin};
     use test_case::test_case;
 
@@ -963,6 +960,192 @@ mod tests {
                 in_experiment: false
             }
         ));
+    }
+
+    #[test]
+    fn all_flags_detail_is_invalid_when_offline() {
+        let (client, _event_rx) = make_mocked_offline_client();
+        client.start_with_default_executor();
+
+        let context = ContextBuilder::new("bob")
+            .build()
+            .expect("Failed to create context");
+
+        let all_flags = client.all_flags_detail(&context, FlagDetailConfig::new());
+        assert_json_eq!(all_flags, json!({"$valid": false, "$flagsState" : {}}));
+    }
+
+    #[test]
+    fn all_flags_detail_is_invalid_when_not_initialized() {
+        let (client, _event_rx) = make_mocked_client();
+
+        let context = ContextBuilder::new("bob")
+            .build()
+            .expect("Failed to create context");
+
+        let all_flags = client.all_flags_detail(&context, FlagDetailConfig::new());
+        assert_json_eq!(all_flags, json!({"$valid": false, "$flagsState" : {}}));
+    }
+
+
+    #[test]
+    fn all_flags_detail_returns_flag_states() {
+        let (client, _event_rx) = make_mocked_client();
+        client.start_with_default_executor();
+        client
+            .data_store
+            .write()
+            .upsert(
+                "myFlag1",
+                PatchTarget::Flag(StorageItem::Item(basic_flag("myFlag1"))),
+            )
+            .expect("patch should apply");
+        client
+            .data_store
+            .write()
+            .upsert(
+                "myFlag2",
+                PatchTarget::Flag(StorageItem::Item(basic_flag("myFlag2"))),
+            )
+            .expect("patch should apply");
+        let context = ContextBuilder::new("bob")
+            .build()
+            .expect("Failed to create context");
+
+        let all_flags = client.all_flags_detail(&context, FlagDetailConfig::new());
+
+        client.close();
+
+        assert_json_eq!(all_flags, json!({
+            "myFlag1": true,
+            "myFlag2": true,
+            "$flagsState": {
+                "myFlag1": {
+                    "version": 42,
+                    "variation": 1
+                },
+                 "myFlag2": {
+                    "version": 42,
+                    "variation": 1
+                },
+            },
+            "$valid": true
+        }));
+    }
+
+
+    #[test]
+    fn all_flags_detail_returns_prerequisite_relations() {
+        let (client, _event_rx) = make_mocked_client();
+        client.start_with_default_executor();
+        client
+            .data_store
+            .write()
+            .upsert(
+                "prereq1",
+                PatchTarget::Flag(StorageItem::Item(basic_flag("prereq1"))),
+            )
+            .expect("patch should apply");
+        client
+            .data_store
+            .write()
+            .upsert(
+                "prereq2",
+                PatchTarget::Flag(StorageItem::Item(basic_flag("prereq2"))),
+            )
+            .expect("patch should apply");
+
+        client.data_store
+            .write()
+            .upsert(
+                "toplevel",
+                PatchTarget::Flag(StorageItem::Item(basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], false))),
+            )
+            .expect("patch should apply");
+
+        let context = ContextBuilder::new("bob")
+            .build()
+            .expect("Failed to create context");
+
+        let all_flags = client.all_flags_detail(&context, FlagDetailConfig::new());
+
+        client.close();
+
+        assert_json_eq!(all_flags, json!({
+            "prereq1": true,
+            "prereq2": true,
+            "toplevel": true,
+            "$flagsState": {
+                "toplevel": {
+                    "version": 42,
+                    "variation": 1,
+                    "prerequisites": ["prereq1", "prereq2"]
+                },
+                "prereq1": {
+                    "version": 42,
+                    "variation": 1
+                },
+                 "prereq2": {
+                    "version": 42,
+                    "variation": 1
+                },
+            },
+            "$valid": true
+        }));
+    }
+
+
+    #[test]
+    fn all_flags_detail_returns_prerequisite_relations_when_not_visible_to_clients() {
+        let (client, _event_rx) = make_mocked_client();
+        client.start_with_default_executor();
+        client
+            .data_store
+            .write()
+            .upsert(
+                "prereq1",
+                PatchTarget::Flag(StorageItem::Item(basic_flag_with_visibility("prereq1", false))),
+            )
+            .expect("patch should apply");
+        client
+            .data_store
+            .write()
+            .upsert(
+                "prereq2",
+                PatchTarget::Flag(StorageItem::Item(basic_flag_with_visibility("prereq2", false))),
+            )
+            .expect("patch should apply");
+
+        client.data_store
+            .write()
+            .upsert(
+                "toplevel",
+                PatchTarget::Flag(StorageItem::Item(basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], true))),
+            )
+            .expect("patch should apply");
+
+        let context = ContextBuilder::new("bob")
+            .build()
+            .expect("Failed to create context");
+
+        let mut config = FlagDetailConfig::new();
+        config.client_side_only();
+
+        let all_flags = client.all_flags_detail(&context,config );
+
+        client.close();
+
+        assert_json_eq!(all_flags, json!({
+            "toplevel": true,
+            "$flagsState": {
+                "toplevel": {
+                    "version": 42,
+                    "variation": 1,
+                    "prerequisites": ["prereq1", "prereq2"]
+                },
+            },
+            "$valid": true
+        }));
     }
 
     #[test]

--- a/launchdarkly-server-sdk/src/evaluation.rs
+++ b/launchdarkly-server-sdk/src/evaluation.rs
@@ -600,6 +600,5 @@ mod tests {
         });
 
         assert_json_eq!(expected, flag_detail);
-
     }
 }

--- a/launchdarkly-server-sdk/src/evaluation.rs
+++ b/launchdarkly-server-sdk/src/evaluation.rs
@@ -103,12 +103,17 @@ pub struct FlagDetail {
     valid: bool,
 }
 
+/// DirectPrerequisiteRecorder records only the direct (top-level) prerequisites of a
+/// flag.
 struct DirectPrerequisiteRecorder {
     target_flag_key: String,
     prerequisites: RefCell<Vec<String>>,
 }
 
 impl DirectPrerequisiteRecorder {
+    /// Creates a new instance of [DirectPrerequisiteRecorder] for a given target flag. The
+    /// direct prerequisites of the flag will be available in the prerequisites field of the
+    /// recorder.
     pub fn new(target_flag_key: impl Into<String>) -> Self {
         Self {
             target_flag_key: target_flag_key.into(),
@@ -218,7 +223,10 @@ mod tests {
     use crate::stores::store::DataStore;
     use crate::stores::store::InMemoryDataStore;
     use crate::stores::store_types::{PatchTarget, StorageItem};
-    use crate::test_common::{basic_flag, basic_flag_with_prereqs_and_visibility, basic_flag_with_visibility, basic_off_flag};
+    use crate::test_common::{
+        basic_flag, basic_flag_with_prereqs_and_visibility, basic_flag_with_visibility,
+        basic_off_flag,
+    };
     use crate::FlagDetailConfig;
     use assert_json_diff::assert_json_eq;
     use launchdarkly_server_sdk_evaluation::ContextBuilder;
@@ -453,7 +461,8 @@ mod tests {
 
         let prereq1 = basic_flag("prereq1");
         let prereq2 = basic_flag("prereq2");
-        let toplevel = basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], false);
+        let toplevel =
+            basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], false);
 
         store
             .upsert("prereq1", PatchTarget::Flag(StorageItem::Item(prereq1)))
@@ -495,7 +504,6 @@ mod tests {
         assert_json_eq!(expected, flag_detail);
     }
 
-
     #[test]
     fn flag_prerequisites_should_be_exposed_even_if_not_available_to_clients() {
         let context = ContextBuilder::new("bob")
@@ -508,7 +516,8 @@ mod tests {
         let prereq2 = basic_flag_with_visibility("prereq2", false);
 
         // But, the top-level flag will.
-        let toplevel = basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], true);
+        let toplevel =
+            basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], true);
 
         store
             .upsert("prereq1", PatchTarget::Flag(StorageItem::Item(prereq1)))
@@ -546,7 +555,6 @@ mod tests {
         assert_json_eq!(expected, flag_detail);
     }
 
-
     #[test]
     fn flag_prerequisites_should_be_in_evaluation_order() {
         let context = ContextBuilder::new("bob")
@@ -559,7 +567,8 @@ mod tests {
         let prereq1 = basic_off_flag("prereq1");
         let prereq2 = basic_flag("prereq2");
 
-        let toplevel = basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], true);
+        let toplevel =
+            basic_flag_with_prereqs_and_visibility("toplevel", &["prereq1", "prereq2"], true);
 
         store
             .upsert("prereq1", PatchTarget::Flag(StorageItem::Item(prereq1)))

--- a/launchdarkly-server-sdk/src/test_common.rs
+++ b/launchdarkly-server-sdk/src/test_common.rs
@@ -7,6 +7,10 @@ use crate::Stage;
 pub const FLOAT_TO_INT_MAX: i64 = 9007199254740991;
 
 pub fn basic_flag(key: &str) -> Flag {
+    return basic_flag_with_visibility(key, false);
+}
+
+pub fn basic_flag_with_visibility(key: &str, visible_to_environment_id: bool) -> Flag {
     serde_json::from_str(&format!(
         r#"{{
             "key": {},
@@ -20,15 +24,15 @@ pub fn basic_flag(key: &str) -> Flag {
             "variations": [false, true],
             "clientSideAvailability": {{
                 "usingMobileKey": false,
-                "usingEnvironmentId": false
+                "usingEnvironmentId": {}
             }},
             "salt": "kosher"
         }}"#,
-        serde_json::Value::String(key.to_string())
+        serde_json::Value::String(key.to_string()),
+        visible_to_environment_id
     ))
-    .unwrap()
+        .unwrap()
 }
-
 pub fn basic_off_flag(key: &str) -> Flag {
     serde_json::from_str(&format!(
         r#"{{
@@ -53,10 +57,12 @@ pub fn basic_off_flag(key: &str) -> Flag {
 }
 
 pub fn basic_flag_with_prereq(key: &str, prereq_key: &str) -> Flag {
-    basic_flag_with_prereqs(key, &[prereq_key])
+    basic_flag_with_prereqs_and_visibility(key, &[prereq_key], false)
 }
 
-pub fn basic_flag_with_prereqs(key: &str, prereq_keys: &[&str]) -> Flag {
+
+
+pub fn basic_flag_with_prereqs_and_visibility(key: &str, prereq_keys: &[&str], visible_to_environment_id: bool) -> Flag {
     let prereqs_json: String = prereq_keys
         .iter()
         .map(|&prereq_key| {
@@ -81,12 +87,13 @@ pub fn basic_flag_with_prereqs(key: &str, prereq_keys: &[&str]) -> Flag {
             "variations": [false, true],
             "clientSideAvailability": {{
                 "usingMobileKey": false,
-                "usingEnvironmentId": false
+                "usingEnvironmentId": {}
             }},
             "salt": "kosher"
         }}"#,
         serde_json::Value::String(key.to_string()),
-        prereqs_json
+        prereqs_json,
+        visible_to_environment_id
     ))
     .unwrap()
 }

--- a/launchdarkly-server-sdk/src/test_common.rs
+++ b/launchdarkly-server-sdk/src/test_common.rs
@@ -53,6 +53,21 @@ pub fn basic_off_flag(key: &str) -> Flag {
 }
 
 pub fn basic_flag_with_prereq(key: &str, prereq_key: &str) -> Flag {
+    basic_flag_with_prereqs(key, &[prereq_key])
+}
+
+pub fn basic_flag_with_prereqs(key: &str, prereq_keys: &[&str]) -> Flag {
+    let prereqs_json: String = prereq_keys
+        .iter()
+        .map(|&prereq_key| {
+            format!(
+                r#"{{"key": {}, "variation": 1}}"#,
+                serde_json::Value::String(prereq_key.to_string())
+            )
+        })
+        .collect::<Vec<String>>()
+        .join(",");
+
     serde_json::from_str(&format!(
         r#"{{
             "key": {},
@@ -60,7 +75,7 @@ pub fn basic_flag_with_prereq(key: &str, prereq_key: &str) -> Flag {
             "on": true,
             "targets": [],
             "rules": [],
-            "prerequisites": [{{"key": {}, "variation": 1}}],
+            "prerequisites": [{}],
             "fallthrough": {{"variation": 1}},
             "offVariation": 0,
             "variations": [false, true],
@@ -71,7 +86,7 @@ pub fn basic_flag_with_prereq(key: &str, prereq_key: &str) -> Flag {
             "salt": "kosher"
         }}"#,
         serde_json::Value::String(key.to_string()),
-        serde_json::Value::String(prereq_key.to_string()),
+        prereqs_json
     ))
     .unwrap()
 }

--- a/launchdarkly-server-sdk/src/test_common.rs
+++ b/launchdarkly-server-sdk/src/test_common.rs
@@ -31,7 +31,7 @@ pub fn basic_flag_with_visibility(key: &str, visible_to_environment_id: bool) ->
         serde_json::Value::String(key.to_string()),
         visible_to_environment_id
     ))
-        .unwrap()
+    .unwrap()
 }
 pub fn basic_off_flag(key: &str) -> Flag {
     serde_json::from_str(&format!(
@@ -60,9 +60,11 @@ pub fn basic_flag_with_prereq(key: &str, prereq_key: &str) -> Flag {
     basic_flag_with_prereqs_and_visibility(key, &[prereq_key], false)
 }
 
-
-
-pub fn basic_flag_with_prereqs_and_visibility(key: &str, prereq_keys: &[&str], visible_to_environment_id: bool) -> Flag {
+pub fn basic_flag_with_prereqs_and_visibility(
+    key: &str,
+    prereq_keys: &[&str],
+    visible_to_environment_id: bool,
+) -> Flag {
     let prereqs_json: String = prereq_keys
         .iter()
         .map(|&prereq_key| {


### PR DESCRIPTION
This PR updates the `FlagDetail` struct returned by `all_flags_detail` to contain prerequisite relations for flags. 