### PR TITLE
Add support for native tls certificates

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -4,14 +4,17 @@ description = "LaunchDarkly Server-Side SDK"
 version = "2.4.1"
 authors = ["LaunchDarkly"]
 edition = "2021"
-rust-version = "1.74.0"  # MSRV
+rust-version = "1.74.0" # MSRV
 license = "Apache-2.0"
 homepage = "https://docs.launchdarkly.com/sdk/server-side/rust"
 repository = "https://github.com/launchdarkly/rust-server-sdk"
-keywords = ["launchdarkly", "launchdarkly-sdk", "feature-flags", "feature-toggles"]
-exclude = [
-    "coverage.sh"
+keywords = [
+    "launchdarkly",
+    "launchdarkly-sdk",
+    "feature-flags",
+    "feature-toggles",
 ]
+exclude = ["coverage.sh"]
 
 [package.metadata.docs.rs]
 features = ["event-compression"]
@@ -34,16 +37,20 @@ tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 parking_lot = "0.12.0"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 moka = { version = "0.12.1", features = ["sync"] }
-uuid = {version = "1.2.2", features = ["v4"] }
+uuid = { version = "1.2.2", features = ["v4"] }
 hyper = { version = "0.14.19", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.24.1" , optional = true}
+hyper-rustls = { version = "0.24.1", optional = true }
 rand = "0.8"
 flate2 = { version = "1.0.35", optional = true }
+rustls-native-certs = { version = "0.6.3", optional = true }
+rustls = "0.21.0"                                                               # Matches the current version used by hyper-rustls
 
 [dev-dependencies]
 maplit = "1.0.1"
 env_logger = "0.10.0"
-serde_json = { version = "1.0.73", features = ["preserve_order"] } # for deterministic JSON testing
+serde_json = { version = "1.0.73", features = [
+    "preserve_order",
+] } # for deterministic JSON testing
 tokio = { version = "1.17.0", features = ["macros", "time"] }
 test-case = "3.2.1"
 mockito = "1.2.0"
@@ -53,7 +60,12 @@ reqwest = { version = "0.12.4", features = ["json"] }
 
 [features]
 default = ["rustls"]
-rustls = ["hyper-rustls/http1", "hyper-rustls/http2", "eventsource-client/rustls"]
+rustls = [
+    "hyper-rustls/http1",
+    "hyper-rustls/http2",
+    "eventsource-client/rustls",
+]
+native-certs = []
 event-compression = ["flate2"]
 
 [[example]]

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -65,7 +65,7 @@ rustls = [
     "hyper-rustls/http2",
     "eventsource-client/rustls",
 ]
-native-certs = []
+native-certs = ["rustls-native-certs"]
 event-compression = ["flate2"]
 
 [[example]]

--- a/launchdarkly-server-sdk/src/events/processor_builders.rs
+++ b/launchdarkly-server-sdk/src/events/processor_builders.rs
@@ -9,6 +9,12 @@ use hyper::service::Service;
 use hyper::Uri;
 #[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnectorBuilder;
+#[cfg(feature = "native-certs")]
+use hyper::client::HttpConnector;
+#[cfg(feature = "native-certs")]
+use hyper_rustls::HttpsConnector;
+#[cfg(feature = "native-certs")]
+use rustls::ClientConfig;
 use launchdarkly_server_sdk_evaluation::Reference;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -88,6 +94,42 @@ pub struct EventProcessorBuilder<C> {
     // diagnostic_recording_interval: Duration
 }
 
+#[cfg(feature = "native-certs")]
+fn create_https_connector_with_native_certs() -> HttpsConnector<HttpConnector> {
+    // Load native certs
+    let mut root_store = rustls::RootCertStore::empty();
+    match rustls_native_certs::load_native_certs() {
+        Ok(certs) => {
+            for cert in certs {
+                root_store
+                    .add(&rustls::Certificate(cert.0))
+                    .unwrap_or_else(|e| {
+                        eprintln!("Failed to add certificate: {}", e);
+                    });
+            }
+            println!("Added {} certificates", root_store.len());
+        }
+        Err(e) => {
+            eprintln!("Failed to load native certificates: {}", e);
+            // Fall back to an empty store, which will likely fail connections
+        }
+    }
+
+    // Create TLS config
+    let tls_config = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    // Build the HTTPS connector
+    HttpsConnectorBuilder::new()
+        .with_tls_config(tls_config)
+        .https_only()
+        .enable_http1()
+        .enable_http2()
+        .build()
+}
+
 impl<C> EventProcessorFactory for EventProcessorBuilder<C>
 where
     C: Service<Uri> + Clone + Send + Sync + 'static,
@@ -124,20 +166,36 @@ where
             } else {
                 #[cfg(feature = "rustls")]
                 {
-                    let connector = HttpsConnectorBuilder::new()
-                        .with_native_roots()
-                        .https_or_http()
-                        .enable_http1()
-                        .enable_http2()
-                        .build();
+                    #[cfg(feature = "native-certs")]
+                    {
+                        let connector = create_https_connector_with_native_certs();
+                        Ok(Arc::new(HyperEventSender::new(
+                            connector,
+                            hyper::Uri::from_str(url_string.as_str()).unwrap(),
+                            sdk_key,
+                            default_headers,
+                            self.compress_events,
+                        )))
+                    }
 
-                    Ok(Arc::new(HyperEventSender::new(
-                        connector,
-                        hyper::Uri::from_str(url_string.as_str()).unwrap(),
-                        sdk_key,
-                        default_headers,
-                        self.compress_events,
-                    )))
+                    #[cfg(not(feature = "native-certs"))]
+                    {
+
+                        let connector = HttpsConnectorBuilder::new()
+                            .with_native_roots()
+                            .https_or_http()
+                            .enable_http1()
+                            .enable_http2()
+                            .build();
+    
+                        Ok(Arc::new(HyperEventSender::new(
+                            connector,
+                            hyper::Uri::from_str(url_string.as_str()).unwrap(),
+                            sdk_key,
+                            default_headers,
+                            self.compress_events,
+                        )))
+                    }
                 }
                 #[cfg(not(feature = "rustls"))]
                 Err(BuildError::InvalidConfig(


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Fixes #106 

**Describe the solution you've provided**

As I described in the issue, the usage of raw rustls fails to load root certs, which causes a crash whenever a TLS connection attempts to be established. I've added a new feature that allows to use the `rustls-native-certs` crate to load the certificates. I've tested the feature in Android but not on other platforms. I'm not super well versed in Rust, but I think the fact that it is behind a feature flag should prevent from accidental breakage.

Comments are more than welcome

**Describe alternatives you've considered**

I don't know if there is any other way to get this to work with hyper-rustls. In our app we are using Reqwest with native-tls and that works fine, but not sure why this crate relies on the low level hyper implementation.
