### PR TITLE
feat: Expose NullDataSourceBuilder from crate root

### DIFF
--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -269,6 +269,16 @@ impl Client {
         Ok(true)
     }
 
+    /// Forcefully sets the client to initialized without making any outbound calls.
+    ///
+    /// This acts as a pseudo-offline mode, where the `DataStore` is still read from. This should only be used in
+    /// cases where the `DataStore` is managed outside of launchdarkly-server-sdk.
+    pub fn force_initialized(&self) {
+        self.started.store(true, Ordering::SeqCst);
+        self.init_state
+            .store(ClientInitState::Initialized as usize, Ordering::SeqCst);
+    }
+
     /// This is an async method that will resolve once initialization is complete.
     /// Initialization being complete does not mean that initialization was a success.
     /// The return value from the method indicates if the client successfully initialized.

--- a/launchdarkly-server-sdk/src/data_source_builders.rs
+++ b/launchdarkly-server-sdk/src/data_source_builders.rs
@@ -144,10 +144,13 @@ impl<C> Default for StreamingDataSourceBuilder<C> {
     }
 }
 
+/// An implementation of DataSourceFactory that will not make any outbound calls. This should
+/// only be used when filling a DataStore externally.
 #[derive(Clone)]
 pub struct NullDataSourceBuilder {}
 
 impl NullDataSourceBuilder {
+    /// Create a new [NullDataSourceBuilder] with all default values.
     pub fn new() -> Self {
         Self {}
     }

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -29,7 +29,8 @@ pub use client::Client;
 pub use client::{BuildError, StartError};
 pub use config::{ApplicationInfo, BuildError as ConfigBuildError, Config, ConfigBuilder};
 pub use data_source_builders::{
-    BuildError as DataSourceBuildError, PollingDataSourceBuilder, StreamingDataSourceBuilder,
+    BuildError as DataSourceBuildError, NullDataSourceBuilder, PollingDataSourceBuilder,
+    StreamingDataSourceBuilder,
 };
 pub use evaluation::{FlagDetail, FlagDetailConfig};
 pub use events::event::MigrationOpEvent;


### PR DESCRIPTION
This may seem a bit strange at first, but it's extremely useful when a persistent `DataStore` is filled externally to the LaunchDarkly SDK.

In our particular use case, we implement a `PersistentDataStore` using an internal blend of Kafka and RocksDB to allow us to isolate the outbound calls towards LD to a single service.

An alternative to this is allowing `offline` mode to continue reading from the `DataStore`, but this is a breaking change.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
