### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` was updated (launchdarkly/gh-actions#86) to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants. Without an explicit `permissions` block in the caller, the called job fails with `startup_failure`. Same fix as launchdarkly/sdk-meta#429.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` check on this PR exits `success` rather than `startup_failure`
- [ ] Confirm only `pull-requests: read` is granted — no broader permissions added

### Notes

No product code is changed. This is part of a batch fix across SDK repos that use the reusable `lint-pr-title` workflow.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change confined to GitHub Actions permissions, granting only read access to pull requests to fix a workflow startup failure.
> 
> **Overview**
> Ensures the `Lint PR title` GitHub Actions workflow can run by explicitly granting **`pull-requests: read`** at the workflow level in `.github/workflows/lint-pr-title.yml`, matching the permissions required by the referenced reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f5029845d7f42f9290419bd397899720457cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->