### PR TITLE
fix: keep StreamingDataSource alive on non-Eof stream errors

### DIFF
--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -143,18 +143,19 @@ impl DataSource for StreamingDataSource {
                                 }
                             },
                             Some(Err(e)) => {
-                                match e {
-                                    es::Error::Eof => {
-                                        continue;
-                                    }
-                                    _ => {
-                                        error!("unhandled error on event stream: {e:?}");
-                                        break;
-                                    }
-                                }
+                                // The eventsource-client owns reconnection;
+                                // breaking here would drop this task and leave
+                                // the data source silently dysfunctional.
+                                warn!("recoverable error on event stream, will retry: {e:?}");
+                                continue;
                             },
                             None => {
-                                error!("unexpected end of event stream");
+                                // The stream is exhausted only when the
+                                // eventsource-client has given up reconnecting.
+                                // Signal initialization failure so the caller
+                                // can observe the permanent failure.
+                                error!("event stream closed permanently");
+                                notify_init.call_once(|| (init_complete)(false));
                                 break;
                             }
                         };
@@ -431,6 +432,53 @@ mod tests {
 
         let _ = shutdown_tx.send(());
         mock.assert()
+    }
+
+    // When the SSE stream returns a non-Eof error, the streaming data
+    // source should keep polling so the eventsource-client can reconnect.
+    // A naive `break` would drop the spawned task and leave the data
+    // source silently dysfunctional.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn streaming_source_recovers_from_non_eof_stream_error() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Bytes 0xFF 0xFE form an invalid UTF-8 sequence; the eventsource
+        // parser rejects the line as `Error::InvalidLine`, which exercises
+        // the catch-all error arm of the fetch loop.
+        let invalid_body: &[u8] = b"\xff\xfe:bad\n\n";
+        let mock = server
+            .mock("GET", "/all")
+            .with_status(200)
+            .with_body(invalid_body)
+            .expect_at_least(2)
+            .create_async()
+            .await;
+
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+
+        let streaming = StreamingDataSource::new(
+            &server.url(),
+            "sdk-key",
+            Duration::from_millis(10),
+            &None,
+            launchdarkly_sdk_transport::HyperTransport::new().expect("Failed to create transport"),
+        )
+        .unwrap();
+
+        let data_store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+
+        streaming.subscribe(
+            data_store,
+            Arc::new(move |_success| {}),
+            shutdown_tx.subscribe(),
+        );
+
+        // Wait long enough for the initial request, the parser error, and
+        // several reconnect attempts (initial_reconnect_delay is 10ms).
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = shutdown_tx.send(());
+
+        mock.assert();
     }
 
     #[test_case(Some("application-id/abc:application-sha/xyz".into()), "application-id/abc:application-sha/xyz")]

--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -481,6 +481,56 @@ mod tests {
         mock.assert();
     }
 
+    // An unrecoverable HTTP status (e.g. 401) should stop the streaming
+    // data source from making further requests and signal init failure
+    // to the caller, rather than retrying indefinitely.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn streaming_source_stops_on_unrecoverable_http_status() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/all")
+            .with_status(401)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let init_outcome = Arc::new(Mutex::new(None::<bool>));
+
+        let streaming = StreamingDataSource::new(
+            &server.url(),
+            "sdk-key",
+            Duration::from_millis(10),
+            &None,
+            launchdarkly_sdk_transport::HyperTransport::new().expect("Failed to create transport"),
+        )
+        .unwrap();
+
+        let data_store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+
+        let init_outcome_clone = init_outcome.clone();
+        streaming.subscribe(
+            data_store,
+            Arc::new(move |success| {
+                *init_outcome_clone.lock().unwrap() = Some(success);
+            }),
+            shutdown_tx.subscribe(),
+        );
+
+        // Wait long enough that any reconnect attempts would have happened
+        // (initial_reconnect_delay is 10ms).
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = shutdown_tx.send(());
+
+        assert_eq!(
+            *init_outcome.lock().unwrap(),
+            Some(false),
+            "expected init_complete(false) on unrecoverable HTTP status"
+        );
+        mock.assert();
+    }
+
     #[test_case(Some("application-id/abc:application-sha/xyz".into()), "application-id/abc:application-sha/xyz")]
     #[test_case(None, Matcher::Missing)]
     #[tokio::test(flavor = "multi_thread")]

--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -142,11 +142,20 @@ impl DataSource for StreamingDataSource {
                                     }
                                 }
                             },
+                            Some(Err(es::Error::Eof)) => {
+                                // Clean end-of-stream from the server;
+                                // routine for streams that rotate connections.
+                                debug!("event stream eof, will reconnect");
+                                continue;
+                            },
                             Some(Err(e)) => {
-                                // The eventsource-client owns reconnection;
-                                // breaking here would drop this task and leave
-                                // the data source silently dysfunctional.
-                                warn!("recoverable error on event stream, will retry: {e:?}");
+                                // Keep polling. The eventsource-client will
+                                // either reconnect on the next poll or end
+                                // the stream (we'll observe that as `None`
+                                // on the next iteration). Breaking here
+                                // would drop this task and leave the data
+                                // source silently dysfunctional.
+                                warn!("error on event stream, will keep polling: {e:?}");
                                 continue;
                             },
                             None => {
@@ -455,6 +464,7 @@ mod tests {
             .await;
 
         let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let init_outcome = Arc::new(Mutex::new(None::<bool>));
 
         let streaming = StreamingDataSource::new(
             &server.url(),
@@ -467,9 +477,12 @@ mod tests {
 
         let data_store = Arc::new(RwLock::new(InMemoryDataStore::new()));
 
+        let init_outcome_clone = init_outcome.clone();
         streaming.subscribe(
             data_store,
-            Arc::new(move |_success| {}),
+            Arc::new(move |success| {
+                *init_outcome_clone.lock().unwrap() = Some(success);
+            }),
             shutdown_tx.subscribe(),
         );
 
@@ -478,6 +491,14 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         let _ = shutdown_tx.send(());
 
+        // While the eventsource-client is still actively reconnecting, the
+        // SDK should treat the situation as transient and not signal init
+        // failure. (Permanent failure is exercised by the 401 test.)
+        assert_eq!(
+            *init_outcome.lock().unwrap(),
+            None,
+            "init_complete should not be called while the stream is still retrying"
+        );
         mock.assert();
     }
 

--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -149,13 +149,13 @@ impl DataSource for StreamingDataSource {
                                 continue;
                             },
                             Some(Err(e)) => {
-                                // Keep polling. The eventsource-client will
-                                // either reconnect on the next poll or end
-                                // the stream (we'll observe that as `None`
-                                // on the next iteration). Breaking here
-                                // would drop this task and leave the data
-                                // source silently dysfunctional.
-                                warn!("error on event stream, will keep polling: {e:?}");
+                                // Continue. The eventsource-client will
+                                // either reconnect on its own or end the
+                                // stream (we'll observe that as `None` on
+                                // the next iteration). Breaking here would
+                                // drop this task and leave the data source
+                                // silently dysfunctional.
+                                warn!("error on event stream, continuing: {e:?}");
                                 continue;
                             },
                             None => {


### PR DESCRIPTION
## Summary

The `StreamingDataSource` fetch loop matched any error other than `Eof` (and recoverable HTTP responses) with a catch-all `_ => break`, dropping the spawned task and leaving the data source silently dysfunctional. Because nothing was polling the eventsource-client's stream anymore, its reconnect logic never ran. The `None` branch also broke without notifying the caller.

This PR:

- Replaces the catch-all `break` with `continue`, so the eventsource-client gets to reconnect on the next poll. A warning log keeps transient errors visible.
- Calls `init_complete(false)` in the `None` branch before breaking, so callers waiting on initialization get a signal when the stream is permanently closed.

## Context

Surfaced from [launchdarkly/rust-server-sdk#116](https://github.com/launchdarkly/rust-server-sdk/issues/116). That report has two contributing bugs; this PR addresses the rust-server-sdk side. The matching rust-eventsource-client side is in [launchdarkly/rust-eventsource-client#134](https://github.com/launchdarkly/rust-eventsource-client/pull/134) ([SDK-2345](https://launchdarkly.atlassian.net/browse/SDK-2345)). Together they restore the reconnection contract: the eventsource-client owns reconnection, and the SDK keeps polling and trusts it.

Tracked in [SDK-2346](https://launchdarkly.atlassian.net/browse/SDK-2346).

## Test plan

- [x] New test `streaming_source_recovers_from_non_eof_stream_error` (`launchdarkly-server-sdk/src/data_source.rs`) — sends invalid UTF-8 that triggers `Error::InvalidLine` from the eventsource-client parser and asserts the mock receives at least two requests, proving the SDK kept polling and the underlying client reconnected.
- [x] `cargo test --package launchdarkly-server-sdk --lib` — 300 tests pass; no regressions.
- [x] `cargo fmt --check` clean.

Closes #116.

[SDK-2345]: https://launchdarkly.atlassian.net/browse/SDK-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming update loop behavior; a mistake could cause retry storms or incorrect initialization signaling, though scope is limited and covered by new tests.
> 
> **Overview**
> Fixes `StreamingDataSource` to **stay alive on non-EOF SSE errors** by continuing the fetch loop (allowing the underlying eventsource client to reconnect) and downgrading the failure to a warning.
> 
> When the event stream is permanently exhausted (`None`), it now **signals initialization failure** via `init_complete(false)` before exiting. Adds tests to verify reconnect attempts on parser errors and stopping/signaling failure on unrecoverable HTTP statuses (e.g. `401`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f3cc4f38dbc4437db7165eba7afb1b68a0a2a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->