### PR TITLE
feat: Add FDv2 wire format and protocol handler

### DIFF
--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,2 +1,3 @@
+mod model;
 mod protocol;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,0 +1,2 @@
+mod protocol;
+mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/model.rs
+++ b/launchdarkly-server-sdk/src/fdv2/model.rs
@@ -1,0 +1,23 @@
+use super::wire::{DeleteObject, PutObject};
+
+pub(super) type Selector = Option<String>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ChangeSetKind {
+    None,
+    Full,
+    Partial,
+}
+
+#[derive(Debug)]
+pub(super) enum FDv2Change {
+    Put(PutObject),
+    Delete(DeleteObject),
+}
+
+#[derive(Debug)]
+pub(super) struct ChangeSet {
+    pub(super) kind: ChangeSetKind,
+    pub(super) changes: Vec<FDv2Change>,
+    pub(super) selector: Selector,
+}

--- a/launchdarkly-server-sdk/src/fdv2/protocol.rs
+++ b/launchdarkly-server-sdk/src/fdv2/protocol.rs
@@ -1,6 +1,6 @@
+use super::model::{ChangeSet, ChangeSetKind, FDv2Change};
 use super::wire::{
-    ChangeSet, ChangeSetKind, DeleteObject, FDv2Change, FDv2Error, Goodbye, IntentCode,
-    PayloadTransferred, PutObject, Selector, ServerIntent,
+    DeleteObject, FDv2Error, Goodbye, IntentCode, PayloadTransferred, PutObject, ServerIntent,
 };
 
 pub(super) enum ProtocolResult {
@@ -86,7 +86,7 @@ impl FDv2ProtocolHandler {
                 ProtocolResult::ChangeSet(ChangeSet {
                     kind: ChangeSetKind::None,
                     changes: Vec::new(),
-                    selector: Selector::Empty,
+                    selector: None,
                 })
             }
             IntentCode::Unknown => {
@@ -150,9 +150,7 @@ impl FDv2ProtocolHandler {
         let changeset = ChangeSet {
             kind,
             changes: std::mem::take(&mut self.changes),
-            selector: Selector::Set {
-                state: transferred.state,
-            },
+            selector: Some(transferred.state),
         };
         // Subsequent put/delete + payload-transferred cycles continue as
         // partial transfers without a new server-intent.
@@ -241,12 +239,7 @@ mod tests {
         assert_eq!(del.key, "old");
         assert_eq!(del.version, 2);
 
-        assert_eq!(
-            cs.selector,
-            Selector::Set {
-                state: "s-1".into(),
-            },
-        );
+        assert_eq!(cs.selector.as_deref(), Some("s-1"));
     }
 
     #[test]
@@ -270,7 +263,7 @@ mod tests {
         let cs = expect_changeset(h.handle_event("server-intent", server_intent("none")));
         assert_eq!(cs.kind, ChangeSetKind::None);
         assert!(cs.changes.is_empty());
-        assert_eq!(cs.selector, Selector::Empty);
+        assert!(cs.selector.is_none());
     }
 
     #[test]

--- a/launchdarkly-server-sdk/src/fdv2/protocol.rs
+++ b/launchdarkly-server-sdk/src/fdv2/protocol.rs
@@ -1,0 +1,367 @@
+use super::wire::{
+    ChangeSet, ChangeSetKind, DeleteObject, FDv2Change, FDv2Error, Goodbye, IntentCode,
+    PayloadTransferred, PutObject, Selector, ServerIntent,
+};
+
+pub(super) enum ProtocolResult {
+    None,
+    ChangeSet(ChangeSet),
+    Error(ProtocolError),
+    Goodbye(Goodbye),
+}
+
+#[derive(Debug)]
+pub(super) enum ProtocolError {
+    JsonParse(String),
+    Protocol(String),
+    Server(FDv2Error),
+}
+
+enum State {
+    Inactive,
+    Full,
+    Partial,
+}
+
+pub(super) struct FDv2ProtocolHandler {
+    state: State,
+    changes: Vec<FDv2Change>,
+}
+
+impl FDv2ProtocolHandler {
+    pub(super) fn new() -> Self {
+        Self {
+            state: State::Inactive,
+            changes: Vec::new(),
+        }
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.state = State::Inactive;
+        self.changes.clear();
+    }
+
+    pub(super) fn handle_event(
+        &mut self,
+        event_type: &str,
+        data: serde_json::Value,
+    ) -> ProtocolResult {
+        match event_type {
+            "server-intent" => self.handle_server_intent(data),
+            "put-object" => self.handle_put_object(data),
+            "delete-object" => self.handle_delete_object(data),
+            "payload-transferred" => self.handle_payload_transferred(data),
+            "error" => self.handle_error(data),
+            "goodbye" => self.handle_goodbye(data),
+            _ => ProtocolResult::None,
+        }
+    }
+
+    fn handle_server_intent(&mut self, data: serde_json::Value) -> ProtocolResult {
+        let intent: ServerIntent = match serde_json::from_value(data) {
+            Ok(v) => v,
+            Err(e) => {
+                self.reset();
+                return ProtocolResult::Error(ProtocolError::JsonParse(format!(
+                    "could not deserialize server-intent: {e}"
+                )));
+            }
+        };
+        let Some(payload) = intent.payloads.into_iter().next() else {
+            self.reset();
+            return ProtocolResult::None;
+        };
+        self.changes.clear();
+        match payload.intent_code {
+            IntentCode::XferFull => {
+                self.state = State::Full;
+                ProtocolResult::None
+            }
+            IntentCode::XferChanges => {
+                self.state = State::Partial;
+                ProtocolResult::None
+            }
+            IntentCode::None => {
+                self.state = State::Partial;
+                ProtocolResult::ChangeSet(ChangeSet {
+                    kind: ChangeSetKind::None,
+                    changes: Vec::new(),
+                    selector: Selector::Empty,
+                })
+            }
+            IntentCode::Unknown => {
+                self.reset();
+                ProtocolResult::Error(ProtocolError::Protocol(
+                    "server-intent had an unrecognized intent code".into(),
+                ))
+            }
+        }
+    }
+
+    fn handle_put_object(&mut self, data: serde_json::Value) -> ProtocolResult {
+        let put: PutObject = match serde_json::from_value(data) {
+            Ok(v) => v,
+            Err(e) => {
+                self.reset();
+                return ProtocolResult::Error(ProtocolError::JsonParse(format!(
+                    "could not deserialize put-object: {e}"
+                )));
+            }
+        };
+        self.changes.push(FDv2Change::Put {
+            kind: put.kind,
+            key: put.key,
+            version: put.version,
+            object: put.object,
+        });
+        ProtocolResult::None
+    }
+
+    fn handle_delete_object(&mut self, data: serde_json::Value) -> ProtocolResult {
+        let del: DeleteObject = match serde_json::from_value(data) {
+            Ok(v) => v,
+            Err(e) => {
+                self.reset();
+                return ProtocolResult::Error(ProtocolError::JsonParse(format!(
+                    "could not deserialize delete-object: {e}"
+                )));
+            }
+        };
+        self.changes.push(FDv2Change::Delete {
+            kind: del.kind,
+            key: del.key,
+            version: del.version,
+        });
+        ProtocolResult::None
+    }
+
+    fn handle_payload_transferred(&mut self, data: serde_json::Value) -> ProtocolResult {
+        if matches!(self.state, State::Inactive) {
+            self.reset();
+            return ProtocolResult::Error(ProtocolError::Protocol(
+                "payload-transferred received without an active server-intent".into(),
+            ));
+        }
+        let transferred: PayloadTransferred = match serde_json::from_value(data) {
+            Ok(v) => v,
+            Err(e) => {
+                self.reset();
+                return ProtocolResult::Error(ProtocolError::JsonParse(format!(
+                    "could not deserialize payload-transferred: {e}"
+                )));
+            }
+        };
+        let kind = match self.state {
+            State::Full => ChangeSetKind::Full,
+            State::Partial => ChangeSetKind::Partial,
+            State::Inactive => unreachable!(),
+        };
+        let changeset = ChangeSet {
+            kind,
+            changes: std::mem::take(&mut self.changes),
+            selector: Selector::Set {
+                state: transferred.state,
+                version: transferred.version,
+            },
+        };
+        // Subsequent put/delete + payload-transferred cycles continue as
+        // partial transfers without a new server-intent.
+        self.state = State::Partial;
+        ProtocolResult::ChangeSet(changeset)
+    }
+
+    fn handle_error(&mut self, data: serde_json::Value) -> ProtocolResult {
+        self.changes.clear();
+        match serde_json::from_value::<FDv2Error>(data) {
+            Ok(err) => ProtocolResult::Error(ProtocolError::Server(err)),
+            Err(e) => ProtocolResult::Error(ProtocolError::JsonParse(format!(
+                "could not deserialize error event: {e}"
+            ))),
+        }
+    }
+
+    fn handle_goodbye(&mut self, data: serde_json::Value) -> ProtocolResult {
+        self.reset();
+        // Parse failures are intentional: the caller rotates sources whether
+        // or not the reason field is readable.
+        let goodbye = serde_json::from_value::<Goodbye>(data).unwrap_or(Goodbye {
+            reason: None,
+            protocol_fallback_ttl: None,
+        });
+        ProtocolResult::Goodbye(goodbye)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn server_intent(code: &str) -> serde_json::Value {
+        json!({"payloads": [{"id": "p", "target": 1, "intentCode": code}]})
+    }
+
+    fn put_flag(key: &str, version: u64) -> serde_json::Value {
+        json!({"version": version, "kind": "flag", "key": key, "object": {"on": true}})
+    }
+
+    fn delete_segment(key: &str, version: u64) -> serde_json::Value {
+        json!({"version": version, "kind": "segment", "key": key})
+    }
+
+    fn payload_transferred(state: &str, version: u64) -> serde_json::Value {
+        json!({"state": state, "version": version})
+    }
+
+    fn expect_changeset(result: ProtocolResult) -> ChangeSet {
+        match result {
+            ProtocolResult::ChangeSet(cs) => cs,
+            _ => panic!("expected ChangeSet"),
+        }
+    }
+
+    #[test]
+    fn full_cycle_emits_full_changeset() {
+        let mut h = FDv2ProtocolHandler::new();
+        h.handle_event("server-intent", server_intent("xfer-full"));
+        h.handle_event("put-object", put_flag("a", 1));
+        h.handle_event("delete-object", delete_segment("old", 2));
+        let cs =
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1", 7)));
+
+        assert_eq!(cs.kind, ChangeSetKind::Full);
+
+        let FDv2Change::Put {
+            kind,
+            key,
+            version,
+            object,
+        } = &cs.changes[0]
+        else {
+            panic!("expected Put");
+        };
+        assert_eq!(kind, "flag");
+        assert_eq!(key, "a");
+        assert_eq!(*version, 1);
+        assert_eq!(object["on"], json!(true));
+
+        let FDv2Change::Delete { kind, key, version } = &cs.changes[1] else {
+            panic!("expected Delete");
+        };
+        assert_eq!(kind, "segment");
+        assert_eq!(key, "old");
+        assert_eq!(*version, 2);
+
+        assert_eq!(
+            cs.selector,
+            Selector::Set {
+                state: "s-1".into(),
+                version: 7,
+            },
+        );
+    }
+
+    #[test]
+    fn partial_cycle_after_payload_transferred_needs_no_new_intent() {
+        let mut h = FDv2ProtocolHandler::new();
+        h.handle_event("server-intent", server_intent("xfer-full"));
+        h.handle_event("put-object", put_flag("a", 1));
+        let _ = h.handle_event("payload-transferred", payload_transferred("s-1", 7));
+
+        // Without a new server-intent, the next cycle is Partial.
+        h.handle_event("put-object", put_flag("b", 2));
+        let cs =
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-2", 8)));
+        assert_eq!(cs.kind, ChangeSetKind::Partial);
+        assert_eq!(cs.changes.len(), 1);
+    }
+
+    #[test]
+    fn server_intent_none_emits_empty_changeset() {
+        let mut h = FDv2ProtocolHandler::new();
+        let cs = expect_changeset(h.handle_event("server-intent", server_intent("none")));
+        assert_eq!(cs.kind, ChangeSetKind::None);
+        assert!(cs.changes.is_empty());
+        assert_eq!(cs.selector, Selector::Empty);
+    }
+
+    #[test]
+    fn unknown_intent_code_is_protocol_error() {
+        let mut h = FDv2ProtocolHandler::new();
+        let result = h.handle_event("server-intent", server_intent("brand-new"));
+        let ProtocolResult::Error(ProtocolError::Protocol(msg)) = result else {
+            panic!("expected Protocol error");
+        };
+        assert!(msg.contains("unrecognized intent code"));
+    }
+
+    #[test]
+    fn payload_transferred_without_intent_is_protocol_error() {
+        let mut h = FDv2ProtocolHandler::new();
+        let result = h.handle_event("payload-transferred", payload_transferred("s-1", 1));
+        assert!(matches!(
+            result,
+            ProtocolResult::Error(ProtocolError::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn error_event_clears_accumulated_changes_but_keeps_state() {
+        let mut h = FDv2ProtocolHandler::new();
+        h.handle_event("server-intent", server_intent("xfer-full"));
+        h.handle_event("put-object", put_flag("a", 1));
+
+        let result = h.handle_event("error", json!({"id": "p", "reason": "bad"}));
+        let ProtocolResult::Error(ProtocolError::Server(err)) = result else {
+            panic!("expected Server error");
+        };
+        assert_eq!(err.reason, "bad");
+
+        // State preserved: a new put + payload-transferred should still emit Full.
+        h.handle_event("put-object", put_flag("b", 2));
+        let cs =
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1", 7)));
+        assert_eq!(cs.kind, ChangeSetKind::Full);
+        assert_eq!(cs.changes.len(), 1, "accumulated changes were not cleared");
+    }
+
+    #[test]
+    fn goodbye_resets_handler() {
+        let mut h = FDv2ProtocolHandler::new();
+        h.handle_event("server-intent", server_intent("xfer-full"));
+        h.handle_event("put-object", put_flag("a", 1));
+
+        let result = h.handle_event("goodbye", json!({"reason": "rotating"}));
+        let ProtocolResult::Goodbye(g) = result else {
+            panic!("expected Goodbye");
+        };
+        assert_eq!(g.reason.as_deref(), Some("rotating"));
+
+        // After goodbye, payload-transferred should now be a protocol error
+        // (state is Inactive again).
+        let result = h.handle_event("payload-transferred", payload_transferred("s-1", 1));
+        assert!(matches!(
+            result,
+            ProtocolResult::Error(ProtocolError::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_event_type_is_noop() {
+        let mut h = FDv2ProtocolHandler::new();
+        assert!(matches!(
+            h.handle_event("heartbeat", json!({})),
+            ProtocolResult::None
+        ));
+    }
+
+    #[test]
+    fn malformed_event_data_is_json_error() {
+        let mut h = FDv2ProtocolHandler::new();
+        let result = h.handle_event("server-intent", json!({"payloads": "not-an-array"}));
+        let ProtocolResult::Error(ProtocolError::JsonParse(msg)) = result else {
+            panic!("expected JsonParse error");
+        };
+        assert!(msg.contains("server-intent"));
+    }
+}

--- a/launchdarkly-server-sdk/src/fdv2/protocol.rs
+++ b/launchdarkly-server-sdk/src/fdv2/protocol.rs
@@ -108,12 +108,7 @@ impl FDv2ProtocolHandler {
                 )));
             }
         };
-        self.changes.push(FDv2Change::Put {
-            kind: put.kind,
-            key: put.key,
-            version: put.version,
-            object: put.object,
-        });
+        self.changes.push(FDv2Change::Put(put));
         ProtocolResult::None
     }
 
@@ -127,11 +122,7 @@ impl FDv2ProtocolHandler {
                 )));
             }
         };
-        self.changes.push(FDv2Change::Delete {
-            kind: del.kind,
-            key: del.key,
-            version: del.version,
-        });
+        self.changes.push(FDv2Change::Delete(del));
         ProtocolResult::None
     }
 
@@ -161,7 +152,6 @@ impl FDv2ProtocolHandler {
             changes: std::mem::take(&mut self.changes),
             selector: Selector::Set {
                 state: transferred.state,
-                version: transferred.version,
             },
         };
         // Subsequent put/delete + payload-transferred cycles continue as
@@ -198,7 +188,12 @@ mod tests {
     use serde_json::json;
 
     fn server_intent(code: &str) -> serde_json::Value {
-        json!({"payloads": [{"id": "p", "target": 1, "intentCode": code}]})
+        json!({"payloads": [{
+            "id": "p",
+            "target": 1,
+            "intentCode": code,
+            "reason": "payload-missing",
+        }]})
     }
 
     fn put_flag(key: &str, version: u64) -> serde_json::Value {
@@ -209,8 +204,8 @@ mod tests {
         json!({"version": version, "kind": "segment", "key": key})
     }
 
-    fn payload_transferred(state: &str, version: u64) -> serde_json::Value {
-        json!({"state": state, "version": version})
+    fn payload_transferred(state: &str) -> serde_json::Value {
+        json!({"state": state})
     }
 
     fn expect_changeset(result: ProtocolResult) -> ChangeSet {
@@ -227,36 +222,29 @@ mod tests {
         h.handle_event("put-object", put_flag("a", 1));
         h.handle_event("delete-object", delete_segment("old", 2));
         let cs =
-            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1", 7)));
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1")));
 
         assert_eq!(cs.kind, ChangeSetKind::Full);
 
-        let FDv2Change::Put {
-            kind,
-            key,
-            version,
-            object,
-        } = &cs.changes[0]
-        else {
+        let FDv2Change::Put(put) = &cs.changes[0] else {
             panic!("expected Put");
         };
-        assert_eq!(kind, "flag");
-        assert_eq!(key, "a");
-        assert_eq!(*version, 1);
-        assert_eq!(object["on"], json!(true));
+        assert_eq!(put.kind, "flag");
+        assert_eq!(put.key, "a");
+        assert_eq!(put.version, 1);
+        assert_eq!(put.object["on"], json!(true));
 
-        let FDv2Change::Delete { kind, key, version } = &cs.changes[1] else {
+        let FDv2Change::Delete(del) = &cs.changes[1] else {
             panic!("expected Delete");
         };
-        assert_eq!(kind, "segment");
-        assert_eq!(key, "old");
-        assert_eq!(*version, 2);
+        assert_eq!(del.kind, "segment");
+        assert_eq!(del.key, "old");
+        assert_eq!(del.version, 2);
 
         assert_eq!(
             cs.selector,
             Selector::Set {
                 state: "s-1".into(),
-                version: 7,
             },
         );
     }
@@ -266,12 +254,12 @@ mod tests {
         let mut h = FDv2ProtocolHandler::new();
         h.handle_event("server-intent", server_intent("xfer-full"));
         h.handle_event("put-object", put_flag("a", 1));
-        let _ = h.handle_event("payload-transferred", payload_transferred("s-1", 7));
+        let _ = h.handle_event("payload-transferred", payload_transferred("s-1"));
 
         // Without a new server-intent, the next cycle is Partial.
         h.handle_event("put-object", put_flag("b", 2));
         let cs =
-            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-2", 8)));
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-2")));
         assert_eq!(cs.kind, ChangeSetKind::Partial);
         assert_eq!(cs.changes.len(), 1);
     }
@@ -298,7 +286,7 @@ mod tests {
     #[test]
     fn payload_transferred_without_intent_is_protocol_error() {
         let mut h = FDv2ProtocolHandler::new();
-        let result = h.handle_event("payload-transferred", payload_transferred("s-1", 1));
+        let result = h.handle_event("payload-transferred", payload_transferred("s-1"));
         assert!(matches!(
             result,
             ProtocolResult::Error(ProtocolError::Protocol(_))
@@ -320,7 +308,7 @@ mod tests {
         // State preserved: a new put + payload-transferred should still emit Full.
         h.handle_event("put-object", put_flag("b", 2));
         let cs =
-            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1", 7)));
+            expect_changeset(h.handle_event("payload-transferred", payload_transferred("s-1")));
         assert_eq!(cs.kind, ChangeSetKind::Full);
         assert_eq!(cs.changes.len(), 1, "accumulated changes were not cleared");
     }
@@ -339,7 +327,7 @@ mod tests {
 
         // After goodbye, payload-transferred should now be a protocol error
         // (state is Inactive again).
-        let result = h.handle_event("payload-transferred", payload_transferred("s-1", 1));
+        let result = h.handle_event("payload-transferred", payload_transferred("s-1"));
         assert!(matches!(
             result,
             ProtocolResult::Error(ProtocolError::Protocol(_))

--- a/launchdarkly-server-sdk/src/fdv2/wire.rs
+++ b/launchdarkly-server-sdk/src/fdv2/wire.rs
@@ -18,7 +18,10 @@ pub(super) struct ServerIntent {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct ServerIntentPayload {
+    pub(super) id: String,
+    pub(super) target: u64,
     pub(super) intent_code: IntentCode,
+    pub(super) reason: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -39,8 +42,6 @@ pub(super) struct DeleteObject {
 #[derive(Debug, Deserialize)]
 pub(super) struct PayloadTransferred {
     pub(super) state: String,
-    #[serde(default)]
-    pub(super) version: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,7 +60,7 @@ pub(super) struct FDv2Error {
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum Selector {
     Empty,
-    Set { state: String, version: u64 },
+    Set { state: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,17 +72,8 @@ pub(super) enum ChangeSetKind {
 
 #[derive(Debug)]
 pub(super) enum FDv2Change {
-    Put {
-        kind: String,
-        key: String,
-        version: u64,
-        object: serde_json::Value,
-    },
-    Delete {
-        kind: String,
-        key: String,
-        version: u64,
-    },
+    Put(PutObject),
+    Delete(DeleteObject),
 }
 
 #[derive(Debug)]
@@ -128,11 +120,15 @@ mod tests {
         });
         let intent: ServerIntent = serde_json::from_value(payload).unwrap();
         assert_eq!(intent.payloads.len(), 1);
-        assert_eq!(intent.payloads[0].intent_code, IntentCode::XferFull);
+        let p = &intent.payloads[0];
+        assert_eq!(p.id, "abc");
+        assert_eq!(p.target, 5);
+        assert_eq!(p.intent_code, IntentCode::XferFull);
+        assert_eq!(p.reason, "payload-missing");
     }
 
     #[test]
-    fn put_object_keeps_object_as_raw_json() {
+    fn put_object_keeps_object_as_json_value() {
         let payload = json!({
             "version": 42,
             "kind": "flag",
@@ -144,13 +140,6 @@ mod tests {
         assert_eq!(put.kind, "flag");
         assert_eq!(put.key, "my-flag");
         assert_eq!(put.object["on"], json!(true));
-    }
-
-    #[test]
-    fn payload_transferred_defaults_version_when_absent() {
-        let pt: PayloadTransferred = serde_json::from_value(json!({"state": "s-1"})).unwrap();
-        assert_eq!(pt.state, "s-1");
-        assert_eq!(pt.version, 0);
     }
 
     #[test]

--- a/launchdarkly-server-sdk/src/fdv2/wire.rs
+++ b/launchdarkly-server-sdk/src/fdv2/wire.rs
@@ -57,32 +57,6 @@ pub(super) struct FDv2Error {
     pub(super) reason: String,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(super) enum Selector {
-    Empty,
-    Set { state: String },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ChangeSetKind {
-    None,
-    Full,
-    Partial,
-}
-
-#[derive(Debug)]
-pub(super) enum FDv2Change {
-    Put(PutObject),
-    Delete(DeleteObject),
-}
-
-#[derive(Debug)]
-pub(super) struct ChangeSet {
-    pub(super) kind: ChangeSetKind,
-    pub(super) changes: Vec<FDv2Change>,
-    pub(super) selector: Selector,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/launchdarkly-server-sdk/src/fdv2/wire.rs
+++ b/launchdarkly-server-sdk/src/fdv2/wire.rs
@@ -1,0 +1,180 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum IntentCode {
+    None,
+    XferFull,
+    XferChanges,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ServerIntent {
+    pub(super) payloads: Vec<ServerIntentPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ServerIntentPayload {
+    pub(super) intent_code: IntentCode,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct PutObject {
+    pub(super) version: u64,
+    pub(super) kind: String,
+    pub(super) key: String,
+    pub(super) object: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct DeleteObject {
+    pub(super) version: u64,
+    pub(super) kind: String,
+    pub(super) key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct PayloadTransferred {
+    pub(super) state: String,
+    #[serde(default)]
+    pub(super) version: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct Goodbye {
+    pub(super) reason: Option<String>,
+    #[serde(rename = "protocolFallbackTTL")]
+    pub(super) protocol_fallback_ttl: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FDv2Error {
+    pub(super) id: Option<String>,
+    pub(super) reason: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum Selector {
+    Empty,
+    Set { state: String, version: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ChangeSetKind {
+    None,
+    Full,
+    Partial,
+}
+
+#[derive(Debug)]
+pub(super) enum FDv2Change {
+    Put {
+        kind: String,
+        key: String,
+        version: u64,
+        object: serde_json::Value,
+    },
+    Delete {
+        kind: String,
+        key: String,
+        version: u64,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct ChangeSet {
+    pub(super) kind: ChangeSetKind,
+    pub(super) changes: Vec<FDv2Change>,
+    pub(super) selector: Selector,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn intent_code_parses_known_and_unknown() {
+        assert_eq!(
+            serde_json::from_value::<IntentCode>(json!("none")).unwrap(),
+            IntentCode::None,
+        );
+        assert_eq!(
+            serde_json::from_value::<IntentCode>(json!("xfer-full")).unwrap(),
+            IntentCode::XferFull,
+        );
+        assert_eq!(
+            serde_json::from_value::<IntentCode>(json!("xfer-changes")).unwrap(),
+            IntentCode::XferChanges,
+        );
+        assert_eq!(
+            serde_json::from_value::<IntentCode>(json!("brand-new-code")).unwrap(),
+            IntentCode::Unknown,
+        );
+    }
+
+    #[test]
+    fn server_intent_parses() {
+        let payload = json!({
+            "payloads": [{
+                "id": "abc",
+                "target": 5,
+                "intentCode": "xfer-full",
+                "reason": "payload-missing"
+            }]
+        });
+        let intent: ServerIntent = serde_json::from_value(payload).unwrap();
+        assert_eq!(intent.payloads.len(), 1);
+        assert_eq!(intent.payloads[0].intent_code, IntentCode::XferFull);
+    }
+
+    #[test]
+    fn put_object_keeps_object_as_raw_json() {
+        let payload = json!({
+            "version": 42,
+            "kind": "flag",
+            "key": "my-flag",
+            "object": {"on": true, "variations": [false, true]}
+        });
+        let put: PutObject = serde_json::from_value(payload).unwrap();
+        assert_eq!(put.version, 42);
+        assert_eq!(put.kind, "flag");
+        assert_eq!(put.key, "my-flag");
+        assert_eq!(put.object["on"], json!(true));
+    }
+
+    #[test]
+    fn payload_transferred_defaults_version_when_absent() {
+        let pt: PayloadTransferred = serde_json::from_value(json!({"state": "s-1"})).unwrap();
+        assert_eq!(pt.state, "s-1");
+        assert_eq!(pt.version, 0);
+    }
+
+    #[test]
+    fn goodbye_handles_optional_fields() {
+        let bare: Goodbye = serde_json::from_value(json!({})).unwrap();
+        assert!(bare.reason.is_none());
+        assert!(bare.protocol_fallback_ttl.is_none());
+
+        let full: Goodbye =
+            serde_json::from_value(json!({"reason": "rotation", "protocolFallbackTTL": 30}))
+                .unwrap();
+        assert_eq!(full.reason.as_deref(), Some("rotation"));
+        assert_eq!(full.protocol_fallback_ttl, Some(30));
+    }
+
+    #[test]
+    fn fdv2_error_handles_optional_id() {
+        let with_id: FDv2Error =
+            serde_json::from_value(json!({"id": "payload-1", "reason": "bad"})).unwrap();
+        assert_eq!(with_id.id.as_deref(), Some("payload-1"));
+        assert_eq!(with_id.reason, "bad");
+
+        let no_id: FDv2Error = serde_json::from_value(json!({"reason": "other"})).unwrap();
+        assert!(no_id.id.is_none());
+        assert_eq!(no_id.reason, "other");
+    }
+}

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -60,6 +60,8 @@ mod data_source;
 mod data_source_builders;
 mod evaluation;
 mod events;
+#[allow(dead_code)] // Tested but not yet reachable from production code.
+mod fdv2;
 mod feature_requester;
 mod feature_requester_builders;
 mod migrations;


### PR DESCRIPTION
## Summary

- Introduces the `fdv2` module:
  - wire-format types
  - assembled `ChangeSet` / `Selector` types
  - protocol-handler state machine that folds SSE events into change sets
- Object bodies stay as raw `serde_json::Value`; typed deserialization will live in a later translator.
- Matches the C++ SDK on permissive-parsing choices:
  - `Selector` keeps the deprecated `version` field alongside `state`
  - `Goodbye` and `FDv2Error` use optional fields to tolerate permissively-parsed wire data
- Module is annotated `#[allow(dead_code)]` for now: types are covered by unit tests but not yet reachable from the production data path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New code is test-only and not on the live flag data path; behavior changes only when FDv2 is integrated later.
> 
> **Overview**
> Adds a new **`fdv2`** module (registered in `lib.rs` but **`#[allow(dead_code)]`** until the streaming data path uses it) for LaunchDarkly **FDv2** streaming.
> 
> **Wire layer** (`wire.rs`): deserializes SSE payloads—`server-intent`, `put-object` / `delete-object`, `payload-transferred`, `error`, `goodbye`—with permissive parsing (unknown intent codes → `Unknown`, optional fields on `Goodbye` / `FDv2Error`). Put bodies stay as **`serde_json::Value`** for a later translator.
> 
> **Protocol** (`protocol.rs`): **`FDv2ProtocolHandler`** folds events into **`ChangeSet`** values (`None` / `Full` / `Partial` plus put/delete ops and a selector from `payload-transferred.state`). It tracks full vs partial transfer intent, allows further put/delete cycles without a new `server-intent` after the first payload, clears buffered changes on server `error` while keeping transfer state, and resets on `goodbye`.
> 
> Unit tests cover wire parsing and protocol edge cases (malformed JSON, unknown events, protocol violations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c71c5551e921087adb63bd9f00cbfb5492ac347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->