### PR TITLE
fix: Bump launchdarkly-sdk-transport to 0.1.4

### DIFF
--- a/contract-tests/Cargo.toml
+++ b/contract-tests/Cargo.toml
@@ -10,7 +10,7 @@ actix = "0.13.0"
 actix-web = "4.2.1"
 env_logger = "0.10.0"
 eventsource-client = { version = "0.17.0" }
-launchdarkly-sdk-transport = { version = "0.1.0" }
+launchdarkly-sdk-transport = { version = "0.1.4" }
 log = "0.4.14"
 launchdarkly-server-sdk = { path = "../launchdarkly-server-sdk/", default-features = false, features = ["event-compression"]}
 serde = { version = "1.0.132", features = ["derive"] }

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -21,7 +21,7 @@ chrono = "0.4.19"
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
 eventsource-client = { version = "0.17.0" }
-launchdarkly-sdk-transport = { version = "0.1.0" }
+launchdarkly-sdk-transport = { version = "0.1.4" }
 futures = "0.3.12"
 log = "0.4.14"
 lru = { version = "0.16.3", default-features = false }


### PR DESCRIPTION
## Summary

Follow-up to the `rust-sdk-transport` change (transport 0.1.4 is published).

`launchdarkly-sdk-transport 0.1.4` requires `hyper-http-proxy ^1.1.1`, which removed its dependency on the unmaintained `rustls-pemfile` crate (RUSTSEC-2025-0134). This raises the transport floor from `0.1.0` to `0.1.4` in both `launchdarkly-server-sdk` and `contract-tests` so fresh dependency resolution can no longer select a transport version that drags `rustls-pemfile` into the tree. With this bump, `rustls-pemfile` no longer appears in the resolved dependency tree.

Fixes #176.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version floor only; no runtime or API changes in this repo, with expected benefit of clearing a known advisory from the tree.
> 
> **Overview**
> Raises the minimum **`launchdarkly-sdk-transport`** version from **0.1.0** to **0.1.4** in `launchdarkly-server-sdk` and `contract-tests` so dependency resolution cannot pull in older transport releases that transitively depend on the unmaintained **`rustls-pemfile`** crate (RUSTSEC-2025-0134).
> 
> Transport **0.1.4** aligns with **`hyper-http-proxy ^1.1.1`**, which drops that dependency; this is a manifest-only change with no SDK source edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f82a816465fd7e225f424255808bac78a07181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->