### PR TITLE
feat: Add optional float-roundtrip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ This repository also contains several small [example implementations](./examples
 cargo run --example EXAMPLE_NAME
 ```
 
+## Cargo features
+
+| Feature | Default | Description |
+| --- | --- | --- |
+| `hyper-rustls-native-roots` | yes | Uses `hyper` for HTTP, with `rustls` for TLS and the platform's native certificate roots. |
+| `hyper-rustls-webpki-roots` | no | Uses `hyper` for HTTP, with `rustls` for TLS and the bundled `webpki` certificate roots. |
+| `native-tls` | no | Uses `hyper` for HTTP, with the platform's native TLS implementation. |
+| `hyper` | no | Uses `hyper` for HTTP without selecting a TLS implementation. |
+| `crypto-aws-lc-rs` | yes | Uses `aws-lc-rs` for cryptographic operations. |
+| `crypto-openssl` | no | Uses `openssl` for cryptographic operations. |
+| `event-compression` | yes | Compresses analytics event payloads before sending them to LaunchDarkly. |
+| `float-roundtrip` | yes | Enables `serde_json`'s `float_roundtrip` feature so that fractional JSON numbers deserialize to the same `f64` that Go's `encoding/json` produces. |
+
+### Disabling `float-roundtrip`
+
+`float-roundtrip` is enabled by default because it is what keeps numeric flag values and numeric context attributes consistent with the other LaunchDarkly SDKs. Without it, `serde_json` uses a faster best-effort float parser that can land one unit in the last place away from the correctly-rounded value, so a numeric evaluation could in principle differ from what another SDK computes for the same flag.
+
+Disable it if you would rather have the faster parser and do not depend on that cross-SDK consistency. Because it is a default feature, opting out means turning the defaults off and re-listing the ones you want:
+
+```toml
+launchdarkly-server-sdk = { version = "3", default-features = false, features = [
+    "hyper-rustls-native-roots",
+    "crypto-aws-lc-rs",
+    "event-compression",
+] }
+```
+
+Note that Cargo feature unification is additive and applies to the whole build, so `float_roundtrip` remains enabled if any other crate in your dependency graph asks for it.
+
 ## Learn more
 
 Read our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/server-side/rust).

--- a/contract-tests/Cargo.toml
+++ b/contract-tests/Cargo.toml
@@ -12,7 +12,9 @@ env_logger = "0.10.0"
 eventsource-client = { version = "0.17.0" }
 launchdarkly-sdk-transport = { version = "0.1.0" }
 log = "0.4.14"
-launchdarkly-server-sdk = { path = "../launchdarkly-server-sdk/", default-features = false, features = ["event-compression"]}
+# float-roundtrip is requested explicitly: the contract tests are our cross-SDK consistency
+# check, so the service under test has to parse numbers the way the other SDKs do.
+launchdarkly-server-sdk = { path = "../launchdarkly-server-sdk/", default-features = false, features = ["event-compression", "float-roundtrip"]}
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"
 futures = "0.3.12"

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -25,9 +25,11 @@ launchdarkly-sdk-transport = { version = "0.1.0" }
 futures = "0.3.12"
 log = "0.4.14"
 lru = { version = "0.16.3", default-features = false }
-launchdarkly-server-sdk-evaluation = "2.1.0"
+# Pulled without default features so that the float-roundtrip feature below is what decides
+# whether the evaluation engine parses floats the way Go does.
+launchdarkly-server-sdk-evaluation = { version = "2.2.0", default-features = false }
 serde = { version = "1.0.132", features = ["derive"] }
-serde_json = { version = "1.0.73", features = ["float_roundtrip"] }
+serde_json = { version = "1.0.73" }
 thiserror = "2.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 parking_lot = "0.12.0"
@@ -58,7 +60,8 @@ testing_logger = "0.1.1"
 default = [
     "hyper-rustls-native-roots",
     "crypto-aws-lc-rs",
-    "event-compression"
+    "event-compression",
+    "float-roundtrip"
 ]
 
 crypto-aws-lc-rs = ["dep:aws-lc-rs"]
@@ -85,6 +88,20 @@ native-tls = [
 ]
 
 event-compression = ["flate2"]
+
+# Parse fractional JSON numbers with serde_json's correctly-rounded float parser, so that
+# numeric flag values and numeric context attributes deserialize to the same f64 that Go's
+# encoding/json produces. This keeps evaluations consistent with the other LaunchDarkly SDKs
+# and is why the feature is enabled by default.
+#
+# Disabling it makes serde_json use its faster best-effort parser, which can land one unit in
+# the last place away from the correctly-rounded value. Note that Cargo feature unification is
+# additive and global, so this feature is still on if any other crate in the dependency graph
+# asks for serde_json/float_roundtrip.
+float-roundtrip = [
+    "serde_json/float_roundtrip",
+    "launchdarkly-server-sdk-evaluation/float-roundtrip"
+]
 
 [[example]]
 name = "print_flags"

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -89,10 +89,14 @@ static USER_AGENT: LazyLock<String> =
 
 static EMPTY_HEADER: LazyLock<HeaderValue> = LazyLock::new(|| HeaderValue::from_static(""));
 
-#[cfg(test)]
+#[cfg(all(test, feature = "float-roundtrip"))]
 mod tests {
     use test_case::test_case;
 
+    // Fractional numbers must parse to the same f64 that Go's encoding/json produces, so that
+    // numeric flag values and numeric context attributes behave identically across LaunchDarkly
+    // SDKs. This requires serde_json's correctly-rounded parser, which the float-roundtrip
+    // feature selects.
     #[test_case("130.65331632653061", 130.65331632653061)]
     #[test_case("130.65331632653062", 130.65331632653061)]
     #[test_case("130.65331632653063", 130.65331632653064)]

--- a/launchdarkly-server-sdk/src/reqwest.rs
+++ b/launchdarkly-server-sdk/src/reqwest.rs
@@ -14,14 +14,6 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    #[test_case("130.65331632653061", 130.65331632653061)]
-    #[test_case("130.65331632653062", 130.65331632653061)]
-    #[test_case("130.65331632653063", 130.65331632653064)]
-    fn json_float_serialization_matches_go(float_as_string: &str, expected: f64) {
-        let parsed: f64 = serde_json::from_str(float_as_string).unwrap();
-        assert_eq!(expected, parsed);
-    }
-
     #[test_case(100, true; "CONTINUE_STATUS")]
     #[test_case(200, true; "OK")]
     #[test_case(300, true; "MULTIPLE_CHOICES")]


### PR DESCRIPTION
The SDK has enabled serde_json's float_roundtrip dependency feature
unconditionally since the initial beta release. Cargo feature unification is
additive and applies to the whole build, so that turned the feature on for
every other serde_json user in a consumer's workspace. A customer reported the
resulting float-parsing cost and had to fork the SDK to get out of it.

Move the behavior behind a cargo feature named float-roundtrip, enabled by
default so nothing changes for consumers who do nothing. The feature forwards
to both serde_json and the evaluation crate, and the evaluation crate is now
pulled with default-features = false so that opting out actually takes effect
rather than being silently undone by that crate's own default.

float_roundtrip selects serde_json's correctly-rounded float parser, which is
what makes fractional numbers land on the same f64 that Go's encoding/json
produces and keeps numeric flag values and numeric context attributes
consistent with the other LaunchDarkly SDKs. Verified against serde_json
1.0.150 that this is still load-bearing: with the feature off,
130.65331632653061 parses one unit in the last place low.

The json_float_serialization_matches_go guard test is therefore gated on the
feature, since CI builds several configurations with default features off. It
was duplicated verbatim in reqwest.rs, which has nothing to do with float
parsing; that copy is removed.

The contract-test service depends on the SDK with default features off, so it
now requests float-roundtrip explicitly -- the contract tests are our
cross-SDK consistency check and need to run in the consistent configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default dependency/feature wiring for numeric flag and context parsing; opting out can make evaluations differ from other LaunchDarkly SDKs by one ULP.
> 
> **Overview**
> Moves **serde_json**’s correctly-rounded float parsing behind a new **`float-roundtrip`** Cargo feature (still **on by default**), so consumers can opt out of the slower parser without forking the SDK.
> 
> The feature forwards to **`serde_json/float_roundtrip`** and **`launchdarkly-server-sdk-evaluation/float-roundtrip`**; the evaluation crate is bumped to **2.2.0** with **`default-features = false`** so disabling the feature actually turns off Go-matching float parsing in evaluations. Contract tests request **`float-roundtrip`** explicitly when using **`default-features = false`**.
> 
> Docs add a Cargo features table and guidance for opting out; the Go float parity test is gated on the feature and deduplicated (removed from **`reqwest.rs`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be1eef3df377df4ea47a20499cd6e64c3d78ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->