### PR TITLE
refactor: Adopt the internal Data System architecture

### DIFF
--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 use tokio::sync::{broadcast, Semaphore};
 
 use super::config::Config;
-use super::data_source::DataSource;
 use super::data_source_builders::BuildError as DataSourceError;
+use super::data_system::{DataSystem, FDv1DataSystem};
 use super::evaluation::{FlagDetail, FlagDetailConfig};
 use super::stores::store::DataStore;
 use super::stores::store_builders::BuildError as DataStoreError;
@@ -147,7 +147,7 @@ impl From<usize> for ClientInitState {
 /// Each builder type includes usage examples for the builder.
 pub struct Client {
     event_processor: Arc<dyn EventProcessor>,
-    data_source: Arc<dyn DataSource>,
+    data_system: Arc<dyn DataSystem>,
     data_store: Arc<RwLock<dyn DataStore>>,
     events_default: EventsScope,
     events_with_reasons: EventsScope,
@@ -187,7 +187,11 @@ impl Client {
         let mut data_source_builder = config.data_source_builder().to_owned();
         data_source_builder.set_instance_id(instance_id);
         let data_source = data_source_builder.build(&endpoints, config.sdk_key(), tags.clone())?;
-        let data_store = config.data_store_builder().build()?;
+        let data_system: Arc<dyn DataSystem> = Arc::new(FDv1DataSystem::new(
+            data_source,
+            config.data_store_builder(),
+        )?);
+        let data_store = data_system.store();
 
         let events_default = EventsScope {
             disabled: config.offline(),
@@ -211,7 +215,7 @@ impl Client {
 
         Ok(Client {
             event_processor,
-            data_source,
+            data_system,
             data_store,
             events_default,
             events_with_reasons,
@@ -242,8 +246,7 @@ impl Client {
         let notify = self.init_notify.clone();
         let init_state = self.init_state.clone();
 
-        self.data_source.subscribe(
-            self.data_store.clone(),
+        self.data_system.start(
             Arc::new(move |success| {
                 init_state.store(
                     (if success {

--- a/launchdarkly-server-sdk/src/data_system.rs
+++ b/launchdarkly-server-sdk/src/data_system.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::broadcast;
+
+use crate::data_source::DataSource;
+use crate::stores::store::DataStore;
+use crate::stores::store_builders::{BuildError, DataStoreFactory};
+
+/// Component that owns the data store and keeps it populated from a source.
+pub(crate) trait DataSystem: Send + Sync {
+    fn start(
+        &self,
+        init_complete: Arc<dyn Fn(bool) + Send + Sync>,
+        shutdown_receiver: broadcast::Receiver<()>,
+    );
+
+    /// Shared handle to the store the evaluation path reads from.
+    fn store(&self) -> Arc<RwLock<dyn DataStore>>;
+}
+
+/// Adapter that lets any existing FDv1 `DataSource` satisfy `DataSystem`.
+pub(crate) struct FDv1DataSystem {
+    source: Arc<dyn DataSource>,
+    store: Arc<RwLock<dyn DataStore>>,
+}
+
+impl FDv1DataSystem {
+    pub(crate) fn new(
+        source: Arc<dyn DataSource>,
+        data_store_builder: &dyn DataStoreFactory,
+    ) -> Result<Self, BuildError> {
+        let store = data_store_builder.build()?;
+        Ok(Self { source, store })
+    }
+}
+
+impl DataSystem for FDv1DataSystem {
+    fn start(
+        &self,
+        init_complete: Arc<dyn Fn(bool) + Send + Sync>,
+        shutdown_receiver: broadcast::Receiver<()>,
+    ) {
+        self.source
+            .subscribe(self.store.clone(), init_complete, shutdown_receiver);
+    }
+
+    fn store(&self) -> Arc<RwLock<dyn DataStore>> {
+        self.store.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::data_source::MockDataSource;
+    use crate::stores::store_builders::InMemoryDataStoreBuilder;
+
+    #[tokio::test]
+    async fn start_forwards_to_underlying_data_source() {
+        let source: Arc<dyn DataSource> = Arc::new(MockDataSource::new_with_init_delay(0));
+        let system = FDv1DataSystem::new(source, &InMemoryDataStoreBuilder::new())
+            .expect("in-memory store builds");
+
+        let initialized = Arc::new(AtomicBool::new(false));
+        let init_state = initialized.clone();
+        let init_complete: Arc<dyn Fn(bool) + Send + Sync> =
+            Arc::new(move |success| init_state.store(success, Ordering::SeqCst));
+        let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+
+        system.start(init_complete, shutdown_rx);
+
+        assert!(initialized.load(Ordering::SeqCst));
+        drop(shutdown_tx);
+    }
+}

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -58,6 +58,7 @@ mod client;
 mod config;
 mod data_source;
 mod data_source_builders;
+mod data_system;
 mod evaluation;
 mod events;
 #[allow(dead_code)] // Tested but not yet reachable from production code.


### PR DESCRIPTION
## Summary

Refactors the SDK onto the Data System architecture used by the other
LaunchDarkly SDKs, in preparation for FDv2. This introduces:

- `DataSystem`, an internal trait for the component that owns the data store
  and keeps it populated.
- `FDv1DataSystem`, an adapter that runs the existing `DataSource` behind that
  trait.

The refactor preserves existing behavior and adds no public API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Introduces an internal **Data System** layer so the Rust server SDK matches other LaunchDarkly SDKs and can grow toward FDv2, without changing the public API.
> 
> **`Client`** now holds `Arc<dyn DataSystem>` instead of `Arc<dyn DataSource>`. At build time it wraps the configured FDv1 data source in **`FDv1DataSystem`**, which builds the data store and exposes it via `store()` for evaluation. Startup calls **`data_system.start(...)`** (init callback + shutdown receiver) instead of wiring `data_source.subscribe` directly to the store.
> 
> New module **`data_system.rs`** defines the `DataSystem` trait (own store, keep it populated) and **`FDv1DataSystem`**, which delegates `start` to the existing `DataSource::subscribe`. A unit test asserts that start forwards to the underlying source and reports init success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0d50b1fe84ab07ec3ac86784cb30b62b1b6f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->