### PR TITLE
feat: Add the FDv2 transactional store and change-set translation

### DIFF
--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,3 +1,3 @@
-mod model;
+pub mod model;
 mod protocol;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/model.rs
+++ b/launchdarkly-server-sdk/src/fdv2/model.rs
@@ -124,12 +124,18 @@ mod tests {
         };
         let out = change_set::ChangeSet::try_from(wire).unwrap();
         assert_eq!(out.changes.len(), 3);
-        assert!(matches!(&out.changes[0], ItemChange::Flag { key, item: StorageItem::Item(f) }
-            if key == "f1" && f.key == "f1"));
-        assert!(matches!(&out.changes[1], ItemChange::Segment { key, item: StorageItem::Item(s) }
-            if key == "s1" && s.key == "s1"));
-        assert!(matches!(&out.changes[2], ItemChange::Flag { key, item: StorageItem::Tombstone(3) }
-            if key == "old"));
+        assert!(
+            matches!(&out.changes[0], ItemChange::Flag { key, item: StorageItem::Item(f) }
+            if key == "f1" && f.key == "f1")
+        );
+        assert!(
+            matches!(&out.changes[1], ItemChange::Segment { key, item: StorageItem::Item(s) }
+            if key == "s1" && s.key == "s1")
+        );
+        assert!(
+            matches!(&out.changes[2], ItemChange::Flag { key, item: StorageItem::Tombstone(3) }
+            if key == "old")
+        );
     }
 
     #[test]

--- a/launchdarkly-server-sdk/src/fdv2/model.rs
+++ b/launchdarkly-server-sdk/src/fdv2/model.rs
@@ -1,3 +1,8 @@
+use launchdarkly_server_sdk_evaluation::{Flag, Segment};
+
+use crate::stores::change_set::{self, ItemChange};
+use crate::stores::store_types::StorageItem;
+
 use super::wire::{DeleteObject, PutObject};
 
 pub(crate) type Selector = Option<String>;
@@ -20,4 +25,131 @@ pub(super) struct ChangeSet {
     pub(super) kind: ChangeSetKind,
     pub(super) changes: Vec<FDv2Change>,
     pub(super) selector: Selector,
+}
+
+impl TryFrom<ChangeSet> for change_set::ChangeSet {
+    type Error = serde_json::Error;
+
+    fn try_from(wire_cs: ChangeSet) -> Result<Self, Self::Error> {
+        let ChangeSet {
+            kind,
+            changes,
+            selector,
+        } = wire_cs;
+
+        let mut translated = Vec::with_capacity(changes.len());
+        for change in changes {
+            match change {
+                FDv2Change::Put(put) => match put.kind.as_str() {
+                    "flag" => translated.push(ItemChange::Flag {
+                        key: put.key,
+                        item: StorageItem::Item(serde_json::from_value::<Flag>(put.object)?),
+                    }),
+                    "segment" => translated.push(ItemChange::Segment {
+                        key: put.key,
+                        item: StorageItem::Item(serde_json::from_value::<Segment>(put.object)?),
+                    }),
+                    other => warn!("FDv2: unknown kind '{other}' in put-object, skipping"),
+                },
+                FDv2Change::Delete(del) => match del.kind.as_str() {
+                    "flag" => translated.push(ItemChange::Flag {
+                        key: del.key,
+                        item: StorageItem::Tombstone(del.version),
+                    }),
+                    "segment" => translated.push(ItemChange::Segment {
+                        key: del.key,
+                        item: StorageItem::Tombstone(del.version),
+                    }),
+                    other => warn!("FDv2: unknown kind '{other}' in delete-object, skipping"),
+                },
+            }
+        }
+
+        Ok(change_set::ChangeSet {
+            kind,
+            changes: translated,
+            selector,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_common::{basic_flag, basic_segment};
+    use serde_json::json;
+
+    fn put(kind: &str, key: &str, version: u64, object: serde_json::Value) -> FDv2Change {
+        FDv2Change::Put(PutObject {
+            version,
+            kind: kind.into(),
+            key: key.into(),
+            object,
+        })
+    }
+
+    fn delete(kind: &str, key: &str, version: u64) -> FDv2Change {
+        FDv2Change::Delete(DeleteObject {
+            version,
+            kind: kind.into(),
+            key: key.into(),
+        })
+    }
+
+    #[test]
+    fn none_kind_translates_to_empty_changeset() {
+        let wire = ChangeSet {
+            kind: ChangeSetKind::None,
+            changes: vec![],
+            selector: Some("s-1".into()),
+        };
+        let out = change_set::ChangeSet::try_from(wire).unwrap();
+        assert_eq!(out.kind, ChangeSetKind::None);
+        assert!(out.changes.is_empty());
+        assert_eq!(out.selector.as_deref(), Some("s-1"));
+    }
+
+    #[test]
+    fn typed_puts_and_deletes_pass_through() {
+        let flag_json = serde_json::to_value(basic_flag("f1")).unwrap();
+        let segment_json = serde_json::to_value(basic_segment("s1")).unwrap();
+        let wire = ChangeSet {
+            kind: ChangeSetKind::Full,
+            changes: vec![
+                put("flag", "f1", 1, flag_json),
+                put("segment", "s1", 2, segment_json),
+                delete("flag", "old", 3),
+            ],
+            selector: Some("s-full".into()),
+        };
+        let out = change_set::ChangeSet::try_from(wire).unwrap();
+        assert_eq!(out.changes.len(), 3);
+        assert!(matches!(&out.changes[0], ItemChange::Flag { key, item: StorageItem::Item(f) }
+            if key == "f1" && f.key == "f1"));
+        assert!(matches!(&out.changes[1], ItemChange::Segment { key, item: StorageItem::Item(s) }
+            if key == "s1" && s.key == "s1"));
+        assert!(matches!(&out.changes[2], ItemChange::Flag { key, item: StorageItem::Tombstone(3) }
+            if key == "old"));
+    }
+
+    #[test]
+    fn unknown_kind_is_dropped() {
+        let wire = ChangeSet {
+            kind: ChangeSetKind::Partial,
+            changes: vec![put("mystery", "k", 1, json!({}))],
+            selector: None,
+        };
+        let out = change_set::ChangeSet::try_from(wire).unwrap();
+        assert!(out.changes.is_empty());
+    }
+
+    #[test]
+    fn parse_failure_returns_err() {
+        let wire = ChangeSet {
+            kind: ChangeSetKind::Full,
+            changes: vec![put("flag", "bad", 1, json!({"garbage": true}))],
+            selector: None,
+        };
+        assert!(change_set::ChangeSet::try_from(wire).is_err());
+    }
 }

--- a/launchdarkly-server-sdk/src/fdv2/model.rs
+++ b/launchdarkly-server-sdk/src/fdv2/model.rs
@@ -1,9 +1,9 @@
 use super::wire::{DeleteObject, PutObject};
 
-pub(super) type Selector = Option<String>;
+pub(crate) type Selector = Option<String>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ChangeSetKind {
+pub(crate) enum ChangeSetKind {
     None,
     Full,
     Partial,

--- a/launchdarkly-server-sdk/src/stores/change_set.rs
+++ b/launchdarkly-server-sdk/src/stores/change_set.rs
@@ -1,0 +1,24 @@
+use launchdarkly_server_sdk_evaluation::{Flag, Segment};
+
+use crate::fdv2::model::{ChangeSetKind, Selector};
+
+use super::store_types::StorageItem;
+
+#[derive(Debug)]
+pub(crate) enum ItemChange {
+    Flag {
+        key: String,
+        item: StorageItem<Flag>,
+    },
+    Segment {
+        key: String,
+        item: StorageItem<Segment>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct ChangeSet {
+    pub(crate) kind: ChangeSetKind,
+    pub(crate) changes: Vec<ItemChange>,
+    pub(crate) selector: Selector,
+}

--- a/launchdarkly-server-sdk/src/stores/change_set.rs
+++ b/launchdarkly-server-sdk/src/stores/change_set.rs
@@ -20,5 +20,6 @@ pub(crate) enum ItemChange {
 pub(crate) struct ChangeSet {
     pub(crate) kind: ChangeSetKind,
     pub(crate) changes: Vec<ItemChange>,
+    #[allow(dead_code)] // Read by the orchestrator in a later phase.
     pub(crate) selector: Selector,
 }

--- a/launchdarkly-server-sdk/src/stores/mod.rs
+++ b/launchdarkly-server-sdk/src/stores/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_set;
 pub mod persistent_store;
 pub mod persistent_store_builders;
 pub mod persistent_store_cache;

--- a/launchdarkly-server-sdk/src/stores/store.rs
+++ b/launchdarkly-server-sdk/src/stores/store.rs
@@ -34,6 +34,7 @@ pub trait DataStore: Store + Send + Sync {
 }
 
 /// Trait for a data store that accepts atomic batch updates from FDv2 delivery.
+#[allow(dead_code)] // Consumed by the FDv2 orchestrator in a later phase.
 pub(crate) trait TransactionalDataStore: Send + Sync {
     /// Apply the batch atomically per the change set's kind.
     fn apply(&mut self, change_set: ChangeSet);

--- a/launchdarkly-server-sdk/src/stores/store.rs
+++ b/launchdarkly-server-sdk/src/stores/store.rs
@@ -1,3 +1,5 @@
+use crate::fdv2::model::ChangeSetKind;
+use crate::stores::change_set::{ChangeSet, ItemChange};
 use crate::stores::store_types::{AllData, PatchTarget, StorageItem};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -29,6 +31,12 @@ pub trait DataStore: Store + Send + Sync {
     fn all_flags(&self) -> HashMap<String, Flag>;
     fn upsert(&mut self, key: &str, data: PatchTarget) -> Result<(), UpdateError>;
     fn to_store(&self) -> &dyn Store;
+}
+
+/// Trait for a data store that accepts atomic batch updates from FDv2 delivery.
+pub(crate) trait TransactionalDataStore: Send + Sync {
+    /// Apply the batch atomically per the change set's kind.
+    fn apply(&mut self, change_set: ChangeSet);
 }
 
 /// Default implementation of [DataStore] which holds information in-memory.
@@ -113,6 +121,29 @@ impl DataStore for InMemoryDataStore {
 
     fn to_store(&self) -> &dyn Store {
         self
+    }
+}
+
+impl TransactionalDataStore for InMemoryDataStore {
+    fn apply(&mut self, change_set: ChangeSet) {
+        match change_set.kind {
+            ChangeSetKind::None => return,
+            ChangeSetKind::Full => {
+                self.data.flags.clear();
+                self.data.segments.clear();
+            }
+            ChangeSetKind::Partial => {}
+        }
+        for change in change_set.changes {
+            match change {
+                ItemChange::Flag { key, item } => {
+                    self.data.flags.insert(key, item);
+                }
+                ItemChange::Segment { key, item } => {
+                    self.data.segments.insert(key, item);
+                }
+            }
+        }
     }
 }
 
@@ -365,5 +396,67 @@ mod tests {
             )
             .is_ok());
         assert!(data_store.segment("segment-key").is_none());
+    }
+
+    fn flag_change(key: &str) -> ItemChange {
+        ItemChange::Flag {
+            key: key.to_string(),
+            item: StorageItem::Item(basic_flag(key)),
+        }
+    }
+
+    fn segment_change(key: &str) -> ItemChange {
+        ItemChange::Segment {
+            key: key.to_string(),
+            item: StorageItem::Item(basic_segment(key)),
+        }
+    }
+
+    #[test]
+    fn apply_none_leaves_store_unchanged() {
+        let mut data_store = InMemoryDataStore::new();
+        data_store.init(basic_data());
+
+        data_store.apply(ChangeSet {
+            kind: ChangeSetKind::None,
+            changes: vec![],
+            selector: None,
+        });
+
+        assert_eq!(data_store.flag("flag-key").unwrap().key, "flag-key");
+        assert_eq!(data_store.segment("segment-key").unwrap().key, "segment-key");
+    }
+
+    #[test]
+    fn apply_full_replaces_existing_state() {
+        let mut data_store = InMemoryDataStore::new();
+        data_store.init(basic_data());
+
+        data_store.apply(ChangeSet {
+            kind: ChangeSetKind::Full,
+            changes: vec![flag_change("new-flag"), segment_change("new-segment")],
+            selector: Some("s-1".into()),
+        });
+
+        assert!(data_store.flag("flag-key").is_none());
+        assert!(data_store.segment("segment-key").is_none());
+        assert_eq!(data_store.flag("new-flag").unwrap().key, "new-flag");
+        assert_eq!(data_store.segment("new-segment").unwrap().key, "new-segment");
+    }
+
+    #[test]
+    fn apply_partial_adds_items_and_preserves_others() {
+        let mut data_store = InMemoryDataStore::new();
+        data_store.init(basic_data());
+
+        data_store.apply(ChangeSet {
+            kind: ChangeSetKind::Partial,
+            changes: vec![flag_change("added-flag")],
+            selector: Some("s-2".into()),
+        });
+
+        assert_eq!(data_store.flag("added-flag").unwrap().key, "added-flag");
+        assert_eq!(data_store.flag("flag-key").unwrap().key, "flag-key");
+        assert_eq!(data_store.segment("segment-key").unwrap().key, "segment-key");
     }
 }

--- a/launchdarkly-server-sdk/src/stores/store.rs
+++ b/launchdarkly-server-sdk/src/stores/store.rs
@@ -424,7 +424,10 @@ mod tests {
         });
 
         assert_eq!(data_store.flag("flag-key").unwrap().key, "flag-key");
-        assert_eq!(data_store.segment("segment-key").unwrap().key, "segment-key");
+        assert_eq!(
+            data_store.segment("segment-key").unwrap().key,
+            "segment-key"
+        );
     }
 
     #[test]
@@ -441,7 +444,10 @@ mod tests {
         assert!(data_store.flag("flag-key").is_none());
         assert!(data_store.segment("segment-key").is_none());
         assert_eq!(data_store.flag("new-flag").unwrap().key, "new-flag");
-        assert_eq!(data_store.segment("new-segment").unwrap().key, "new-segment");
+        assert_eq!(
+            data_store.segment("new-segment").unwrap().key,
+            "new-segment"
+        );
     }
 
     #[test]
@@ -457,6 +463,9 @@ mod tests {
 
         assert_eq!(data_store.flag("added-flag").unwrap().key, "added-flag");
         assert_eq!(data_store.flag("flag-key").unwrap().key, "flag-key");
-        assert_eq!(data_store.segment("segment-key").unwrap().key, "segment-key");
+        assert_eq!(
+            data_store.segment("segment-key").unwrap().key,
+            "segment-key"
+        );
     }
 }


### PR DESCRIPTION
## Summary

FDv2 delivers data as change sets that must be applied to the store as atomic batches. This adds the write path for that:

- A `TransactionalDataStore` trait, parallel to `DataStore`, whose `apply` method applies a change set to the store as a single atomic batch, with an implementation for the in-memory store.
- Translation from wire change sets into typed store change sets, deserializing each object into a `Flag` or `Segment`.

Unknown object kinds in a change set are logged and skipped rather than silently ignored, matching the C++ and Java SDKs. The spec calls for silently ignoring them.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds the FDv2 **write path** so wire change sets can be turned into typed store batches and applied atomically (orchestrator wiring is still ahead).
> 
> Introduces store-level `ChangeSet` / `ItemChange` and a `TransactionalDataStore::apply` trait. `InMemoryDataStore` implements it: **None** is a no-op, **Full** clears flags and segments then applies changes, **Partial** merges without clearing. Note that `apply` uses direct map inserts, not the version-gated logic used by `upsert`.
> 
> Wire FDv2 `ChangeSet` is converted via `TryFrom` into the store type: puts deserialize JSON into `Flag` / `Segment`, deletes become tombstones. Unknown put/delete kinds are **warned and skipped** (aligned with C++ / Java SDKs, not silent per spec).
> 
> `fdv2::model` is made `pub` so stores can share `ChangeSetKind` / `Selector`. Tests cover translation (including unknown kinds and parse errors) and `apply` for all three kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e79014061903bd15c5855fde38e48c5c663d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->