### PR TITLE
feat: Add FDv2 source traits and result types

### DIFF
--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,3 +1,4 @@
 pub mod model;
 mod protocol;
+mod source;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -12,11 +12,11 @@ pub(crate) enum ErrorKind {
     NetworkError,
     ErrorResponse { status_code: u16 },
     InvalidData,
-    StoreError,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct ErrorInfo {
+    #[allow(dead_code)] // Will be read by data source status provider, once implemented.
     pub(crate) kind: ErrorKind,
     pub(crate) message: String,
 }
@@ -32,7 +32,7 @@ pub(crate) enum FDv2SourceResult {
     Interrupted(ErrorInfo),
     TerminalError(ErrorInfo),
     Shutdown,
-    Goodbye { reason: Option<String> },
+    Goodbye,
 }
 
 #[derive(Debug)]

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -41,12 +41,12 @@ pub(crate) struct FDv2SourceEvent {
     pub(crate) fdv1_fallback: Option<FDv1FallbackDirective>,
 }
 
-pub(crate) trait Initializer: Send + Sync {
+pub(crate) trait Initializer: Send {
     fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent>;
     fn name(&self) -> &str;
 }
 
-pub(crate) trait Synchronizer: Send + Sync {
+pub(crate) trait Synchronizer: Send {
     fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent>;
     fn name(&self) -> &str;
 }

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+
+use crate::stores::change_set::ChangeSet;
+
+use super::model::Selector;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ErrorKind {
+    Unknown,
+    NetworkError,
+    ErrorResponse { status_code: u16 },
+    InvalidData,
+    StoreError,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ErrorInfo {
+    pub(crate) kind: ErrorKind,
+    pub(crate) message: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct FDv1FallbackDirective {
+    pub(crate) ttl: Duration,
+}
+
+#[derive(Debug)]
+pub(crate) enum FDv2SourceResult {
+    ChangeSet(ChangeSet),
+    Interrupted(ErrorInfo),
+    TerminalError(ErrorInfo),
+    Shutdown,
+    Goodbye { reason: Option<String> },
+}
+
+#[derive(Debug)]
+pub(crate) struct FDv2SourceEvent {
+    pub(crate) result: FDv2SourceResult,
+    pub(crate) fdv1_fallback: Option<FDv1FallbackDirective>,
+}
+
+pub(crate) trait Initializer: Send + Sync {
+    fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent>;
+    fn name(&self) -> &str;
+}
+
+pub(crate) trait Synchronizer: Send + Sync {
+    fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent>;
+    fn name(&self) -> &str;
+}


### PR DESCRIPTION
## Summary

Defines the interfaces the FDv2 data sources implement, ahead of the concrete polling and streaming sources. This adds:

- `Initializer` and `Synchronizer` traits, whose methods return a boxed future so the traits stay object-safe.
- The `FDv2SourceResult` enum returned by those methods, plus its accompanying event and error types.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Introduces **`fdv2/source`** as the contract for upcoming FDv2 polling and streaming data sources.
> 
> **`Initializer`** and **`Synchronizer`** traits define async entry points (`run` and `next(selector)`) that return **`BoxFuture`** so implementations can be used as trait objects. **`FDv2SourceEvent`** wraps **`FDv2SourceResult`** (change sets, recoverable **`Interrupted`** / fatal **`TerminalError`**, **`Shutdown`**, **`Goodbye`**) and optional **`FDv1FallbackDirective`** (TTL) for FDv1 fallback. **`ErrorKind`** / **`ErrorInfo`** classify source failures for a future status provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3361c84d83cbed9829a3ff715c5f4168e457b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->