### PR TITLE
feat: Add the FDv2 polling data source

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -49,7 +49,7 @@ openssl = { version = "0.10.75", optional = true }
 maplit = "1.0.1"
 env_logger = "0.10.0"
 serde_json = { version = "1.0.73", features = ["preserve_order"] } # for deterministic JSON testing
-tokio = { version = "1.17.0", features = ["macros", "time"] }
+tokio = { version = "1.17.0", features = ["macros", "time", "test-util"] }
 test-case = "3.2.1"
 mockito = "1.2.0"
 assert-json-diff = "2.0.2"

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -38,6 +38,7 @@ moka = { version = "0.12.1", features = ["sync"] }
 uuid = {version = "1.2.2", features = ["v4"] }
 http = "1.0"
 bytes = "1.11"
+percent-encoding = "2.3"
 bitflags = "2.4"
 rand = "0.9"
 flate2 = { version = "1.0.35", optional = true }

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,4 +1,5 @@
 pub mod model;
+mod polling;
 mod protocol;
 mod source;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,6 +1,7 @@
 pub mod model;
 mod polling;
 mod protocol;
+mod request_headers;
 mod source;
 mod url;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -2,4 +2,5 @@ pub mod model;
 mod polling;
 mod protocol;
 mod source;
+mod url;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -16,6 +16,9 @@ use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
 use crate::stores::change_set::ChangeSet;
 
+// Minimum polling interval to avoid accidentally hammering the service.
+const MINIMUM_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
 fn interrupted(kind: ErrorKind, message: impl Into<String>) -> FDv2SourceEvent {
     FDv2SourceEvent {
         result: FDv2SourceResult::Interrupted(ErrorInfo {
@@ -250,7 +253,7 @@ impl<T: HttpTransport> PollingSynchronizer<T> {
             base_url,
             sdk_key,
             filter_key,
-            poll_interval,
+            poll_interval: std::cmp::max(poll_interval, MINIMUM_POLL_INTERVAL),
             last_poll_start: None,
         }
     }
@@ -579,31 +582,65 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn synchronizer_next_enforces_poll_interval() {
         use super::super::source::Synchronizer;
         use std::sync::atomic::Ordering;
+
+        // Configure an interval above the floor.
         let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let transport = CountingTransport {
-            count: count.clone(),
-        };
         let mut sync = PollingSynchronizer::new(
-            transport,
+            CountingTransport {
+                count: count.clone(),
+            },
             "http://example.com".to_string(),
             "sdk-key".to_string(),
             None,
-            Duration::from_millis(50),
+            Duration::from_secs(60),
         );
 
-        let start = std::time::Instant::now();
+        // Poll twice, timing the gap on the paused clock.
+        let start = tokio::time::Instant::now();
         let _ = sync.next(None).await;
         let _ = sync.next(None).await;
         let elapsed = start.elapsed();
 
+        // The second poll waited the configured 60s.
         assert_eq!(count.load(Ordering::SeqCst), 2);
         assert!(
-            elapsed >= Duration::from_millis(45),
-            "expected the second poll to wait ~50ms, got total {elapsed:?}",
+            elapsed >= Duration::from_secs(59),
+            "expected the second poll to wait the configured 60s, got {elapsed:?}",
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn synchronizer_clamps_poll_interval_to_minimum() {
+        use super::super::source::Synchronizer;
+        use std::sync::atomic::Ordering;
+
+        // Configure an interval below the floor.
+        let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut sync = PollingSynchronizer::new(
+            CountingTransport {
+                count: count.clone(),
+            },
+            "http://example.com".to_string(),
+            "sdk-key".to_string(),
+            None,
+            Duration::from_secs(1),
+        );
+
+        // Poll twice, timing the gap on the paused clock.
+        let start = tokio::time::Instant::now();
+        let _ = sync.next(None).await;
+        let _ = sync.next(None).await;
+        let elapsed = start.elapsed();
+
+        // The second poll waited the clamped 30s minimum, not the configured 1s.
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            elapsed >= Duration::from_secs(29),
+            "expected the second poll to wait the clamped 30s minimum, got {elapsed:?}",
         );
     }
 

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -10,7 +10,7 @@ use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::source::{
     read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
-    FDv2SourceResult,
+    FDv2SourceResult, RequestHeaders,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
@@ -179,16 +179,21 @@ async fn fetch_and_handle<T: HttpTransport>(
 pub(crate) struct PollingInitializer<T: HttpTransport> {
     transport: T,
     base_url: String,
-    sdk_key: String,
+    headers: RequestHeaders,
     selector: Selector,
 }
 
 impl<T: HttpTransport> PollingInitializer<T> {
-    pub(crate) fn new(transport: T, base_url: String, sdk_key: String, selector: Selector) -> Self {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        headers: RequestHeaders,
+        selector: Selector,
+    ) -> Self {
         Self {
             transport,
             base_url,
-            sdk_key,
+            headers,
             selector,
         }
     }
@@ -197,7 +202,7 @@ impl<T: HttpTransport> PollingInitializer<T> {
 impl<T: HttpTransport> super::source::Initializer for PollingInitializer<T> {
     fn run(&mut self) -> futures::future::BoxFuture<'_, FDv2SourceEvent> {
         Box::pin(async move {
-            let request = match build_poll_request(&self.base_url, &self.sdk_key, &self.selector) {
+            let request = match build_poll_request(&self.base_url, &self.headers, &self.selector) {
                 Ok(r) => r,
                 Err(e) => {
                     return FDv2SourceEvent {
@@ -221,7 +226,7 @@ impl<T: HttpTransport> super::source::Initializer for PollingInitializer<T> {
 pub(crate) struct PollingSynchronizer<T: HttpTransport> {
     transport: T,
     base_url: String,
-    sdk_key: String,
+    headers: RequestHeaders,
     poll_interval: Duration,
     last_poll_start: Option<std::time::Instant>,
 }
@@ -230,13 +235,13 @@ impl<T: HttpTransport> PollingSynchronizer<T> {
     pub(crate) fn new(
         transport: T,
         base_url: String,
-        sdk_key: String,
+        headers: RequestHeaders,
         poll_interval: Duration,
     ) -> Self {
         Self {
             transport,
             base_url,
-            sdk_key,
+            headers,
             poll_interval: std::cmp::max(poll_interval, MINIMUM_POLL_INTERVAL),
             last_poll_start: None,
         }
@@ -257,7 +262,7 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
             self.last_poll_start = Some(std::time::Instant::now());
 
             // Build the poll request.
-            let request = match build_poll_request(&self.base_url, &self.sdk_key, &selector) {
+            let request = match build_poll_request(&self.base_url, &self.headers, &selector) {
                 Ok(r) => r,
                 Err(e) => {
                     return FDv2SourceEvent {
@@ -282,22 +287,27 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
 
 fn build_poll_request(
     base_url: &str,
-    sdk_key: &str,
+    headers: &RequestHeaders,
     selector: &Selector,
 ) -> Result<Request<Option<Bytes>>, http::Error> {
     let url = build_fdv2_url(base_url, "sdk/poll", selector);
-    Request::builder()
+    let mut builder = Request::builder()
         .uri(url)
         .method("GET")
-        .header("Content-Type", "application/json")
-        .header("Authorization", sdk_key)
-        .header("User-Agent", &*crate::USER_AGENT)
-        .body(Some(Bytes::new()))
+        .header("Content-Type", "application/json");
+    for (name, value) in headers.iter() {
+        builder = builder.header(name, value);
+    }
+    builder.body(Some(Bytes::new()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_headers() -> RequestHeaders {
+        RequestHeaders::new("sdk-key", None, "test-instance")
+    }
 
     fn full_payload_body(flag_key: &str) -> Vec<u8> {
         let flag = crate::test_common::basic_flag(flag_key);
@@ -518,7 +528,7 @@ mod tests {
         let mut initializer = PollingInitializer::new(
             transport,
             "http://example.com".to_string(),
-            "sdk-key".to_string(),
+            test_headers(),
             Some("stored-state".to_string()),
         );
         let _ = initializer.run().await;
@@ -536,7 +546,7 @@ mod tests {
         let mut sync = PollingSynchronizer::new(
             transport,
             "http://example.com".to_string(),
-            "sdk-key".to_string(),
+            test_headers(),
             Duration::ZERO,
         );
         let _ = sync.next(Some("per-call-state".to_string())).await;
@@ -570,7 +580,7 @@ mod tests {
                 count: count.clone(),
             },
             "http://example.com".to_string(),
-            "sdk-key".to_string(),
+            test_headers(),
             Duration::from_secs(60),
         );
 
@@ -600,7 +610,7 @@ mod tests {
                 count: count.clone(),
             },
             "http://example.com".to_string(),
-            "sdk-key".to_string(),
+            test_headers(),
             Duration::from_secs(1),
         );
 
@@ -621,7 +631,7 @@ mod tests {
     #[tokio::test]
     async fn network_error_returns_interrupted_without_fallback() {
         let transport = FailingTransport;
-        let req = build_poll_request("http://example.com", "sdk-key", &None).unwrap();
+        let req = build_poll_request("http://example.com", &test_headers(), &None).unwrap();
         let event = fetch_and_handle(&transport, req).await;
         let FDv2SourceResult::Interrupted(err) = event.result else {
             panic!("expected Interrupted");
@@ -680,7 +690,7 @@ mod tests {
         let transport = launchdarkly_sdk_transport::HyperTransport::new().expect("hyper transport");
         use super::super::source::Synchronizer;
         let mut sync =
-            PollingSynchronizer::new(transport, server.url(), "sdk-key".into(), Duration::ZERO);
+            PollingSynchronizer::new(transport, server.url(), test_headers(), Duration::ZERO);
 
         let out = sync.next(None).await;
         let FDv2SourceResult::ChangeSet(cs) = out.result else {

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -8,7 +8,9 @@ use serde::Deserialize;
 
 use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
-use super::source::{ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult};
+use super::source::{
+    ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult,
+};
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
 use crate::stores::change_set::ChangeSet;
@@ -42,7 +44,10 @@ fn parse_poll_body(body: &[u8]) -> FDv2SourceEvent {
     let envelope: PollEnvelope = match serde_json::from_slice(body) {
         Ok(v) => v,
         Err(_) => {
-            return interrupted(ErrorKind::InvalidData, "could not parse FDv2 polling response");
+            return interrupted(
+                ErrorKind::InvalidData,
+                "could not parse FDv2 polling response",
+            );
         }
     };
 
@@ -364,10 +369,7 @@ mod tests {
 
     #[test]
     fn fallback_ttl_header_is_parsed() {
-        let h = headers(&[
-            ("X-LD-FD-Fallback", "true"),
-            ("X-LD-FD-Fallback-TTL", "60"),
-        ]);
+        let h = headers(&[("X-LD-FD-Fallback", "true"), ("X-LD-FD-Fallback-TTL", "60")]);
         let d = read_fallback_directive(&h).expect("directive");
         assert_eq!(d.ttl, Duration::from_secs(60));
     }
@@ -474,7 +476,11 @@ mod tests {
             panic!("expected Interrupted");
         };
         assert_eq!(err.kind, ErrorKind::InvalidData);
-        assert!(err.message.contains("translated"), "message: {}", err.message);
+        assert!(
+            err.message.contains("translated"),
+            "message: {}",
+            err.message
+        );
     }
 
     fn make_response(status: u16, headers: &[(&str, &str)], body: &[u8]) -> Response<ByteStream> {
@@ -634,8 +640,7 @@ mod tests {
             &self,
             _request: Request<Option<Bytes>>,
         ) -> launchdarkly_sdk_transport::ResponseFuture {
-            self.count
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async { Ok(make_response(200, &[], b"{\"events\":[]}")) })
         }
     }

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -234,7 +234,7 @@ pub(crate) struct PollingSynchronizer<T: HttpTransport> {
     sdk_key: String,
     filter_key: Option<String>,
     poll_interval: Duration,
-    last_poll_start: std::sync::Arc<parking_lot::Mutex<Option<std::time::Instant>>>,
+    last_poll_start: Option<std::time::Instant>,
 }
 
 impl<T: HttpTransport> PollingSynchronizer<T> {
@@ -251,7 +251,7 @@ impl<T: HttpTransport> PollingSynchronizer<T> {
             sdk_key,
             filter_key,
             poll_interval,
-            last_poll_start: std::sync::Arc::new(parking_lot::Mutex::new(None)),
+            last_poll_start: None,
         }
     }
 }
@@ -260,17 +260,14 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
     fn next(&mut self, selector: Selector) -> futures::future::BoxFuture<'_, FDv2SourceEvent> {
         Box::pin(async move {
             // Wait for the poll interval to elapse since the previous request.
-            let wait = {
-                let last = self.last_poll_start.lock();
-                match *last {
-                    Some(t) => self.poll_interval.saturating_sub(t.elapsed()),
-                    None => Duration::ZERO,
-                }
+            let wait = match self.last_poll_start {
+                Some(t) => self.poll_interval.saturating_sub(t.elapsed()),
+                None => Duration::ZERO,
             };
             if !wait.is_zero() {
                 tokio::time::sleep(wait).await;
             }
-            *self.last_poll_start.lock() = Some(std::time::Instant::now());
+            self.last_poll_start = Some(std::time::Instant::now());
 
             // Build the poll request.
             let request = match build_poll_request(
@@ -320,7 +317,6 @@ fn build_poll_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::HeaderMap;
 
     fn full_payload_body(flag_key: &str) -> Vec<u8> {
         let flag = crate::test_common::basic_flag(flag_key);
@@ -643,5 +639,49 @@ mod tests {
             event.fdv1_fallback.as_ref().map(|d| d.ttl),
             Some(Duration::from_secs(90))
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn end_to_end_full_payload_emits_changeset() {
+        let mut server = mockito::Server::new_async().await;
+        let flag = crate::test_common::basic_flag("f");
+        let flag_json = serde_json::to_value(&flag).unwrap();
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "server-intent", "data": {"payloads": [{
+                    "id": "p", "target": 1, "intentCode": "xfer-full", "reason": "payload-missing",
+                }]}},
+                {"event": "put-object", "data": {
+                    "version": 1, "kind": "flag", "key": "f", "object": flag_json,
+                }},
+                {"event": "payload-transferred", "data": {"state": "s-1"}},
+            ]
+        });
+        let mock = server
+            .mock("GET", "/sdk/poll")
+            .match_header("Authorization", "sdk-key")
+            .with_status(200)
+            .with_body(envelope.to_string())
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let transport = launchdarkly_sdk_transport::HyperTransport::new().expect("hyper transport");
+        use super::super::source::Synchronizer;
+        let mut sync = PollingSynchronizer::new(
+            transport,
+            server.url(),
+            "sdk-key".into(),
+            None,
+            Duration::ZERO,
+        );
+
+        let out = sync.next(None).await;
+        let FDv2SourceResult::ChangeSet(cs) = out.result else {
+            panic!("expected ChangeSet, got {:?}", out.result);
+        };
+        assert_eq!(cs.selector.as_deref(), Some("s-1"));
+        assert_eq!(cs.changes.len(), 1);
+        mock.assert_async().await;
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -2,22 +2,19 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use http::{HeaderMap, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode};
 use launchdarkly_sdk_transport::{ByteStream, HttpTransport};
 use serde::Deserialize;
 
 use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::source::{
-    ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult,
+    read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
+    FDv2SourceResult,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
 use crate::stores::change_set::ChangeSet;
-
-const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
-const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
-const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
 fn interrupted(kind: ErrorKind, message: impl Into<String>) -> FDv2SourceEvent {
     FDv2SourceEvent {
@@ -304,20 +301,6 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
     }
 }
 
-fn read_fallback_directive(headers: &HeaderMap) -> Option<FDv1FallbackDirective> {
-    let flag = headers.get(FALLBACK_HEADER)?;
-    if !flag.to_str().is_ok_and(|s| s.eq_ignore_ascii_case("true")) {
-        return None;
-    }
-    let ttl = headers
-        .get(FALLBACK_TTL_HEADER)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_FALLBACK_TTL);
-    Some(FDv1FallbackDirective { ttl })
-}
-
 fn build_poll_request(
     base_url: &str,
     sdk_key: &str,
@@ -337,52 +320,7 @@ fn build_poll_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
-        let mut h = HeaderMap::new();
-        for (k, v) in pairs {
-            h.insert(
-                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
-                http::HeaderValue::from_str(v).unwrap(),
-            );
-        }
-        h
-    }
-
-    #[test]
-    fn fallback_absent_header_returns_none() {
-        assert!(read_fallback_directive(&HeaderMap::new()).is_none());
-    }
-
-    #[test]
-    fn fallback_header_value_other_than_true_returns_none() {
-        let h = headers(&[("X-LD-FD-Fallback", "false")]);
-        assert!(read_fallback_directive(&h).is_none());
-    }
-
-    #[test]
-    fn fallback_header_uppercase_true_uses_default_ttl() {
-        let h = headers(&[("X-LD-FD-Fallback", "TRUE")]);
-        let d = read_fallback_directive(&h).expect("directive");
-        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
-    }
-
-    #[test]
-    fn fallback_ttl_header_is_parsed() {
-        let h = headers(&[("X-LD-FD-Fallback", "true"), ("X-LD-FD-Fallback-TTL", "60")]);
-        let d = read_fallback_directive(&h).expect("directive");
-        assert_eq!(d.ttl, Duration::from_secs(60));
-    }
-
-    #[test]
-    fn fallback_ttl_header_malformed_uses_default() {
-        let h = headers(&[
-            ("X-LD-FD-Fallback", "true"),
-            ("X-LD-FD-Fallback-TTL", "not-a-number"),
-        ]);
-        let d = read_fallback_directive(&h).expect("directive");
-        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
-    }
+    use http::HeaderMap;
 
     fn full_payload_body(flag_key: &str) -> Vec<u8> {
         let flag = crate::test_common::basic_flag(flag_key);

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -181,23 +181,15 @@ pub(crate) struct PollingInitializer<T: HttpTransport> {
     base_url: String,
     sdk_key: String,
     selector: Selector,
-    filter_key: Option<String>,
 }
 
 impl<T: HttpTransport> PollingInitializer<T> {
-    pub(crate) fn new(
-        transport: T,
-        base_url: String,
-        sdk_key: String,
-        selector: Selector,
-        filter_key: Option<String>,
-    ) -> Self {
+    pub(crate) fn new(transport: T, base_url: String, sdk_key: String, selector: Selector) -> Self {
         Self {
             transport,
             base_url,
             sdk_key,
             selector,
-            filter_key,
         }
     }
 }
@@ -205,12 +197,7 @@ impl<T: HttpTransport> PollingInitializer<T> {
 impl<T: HttpTransport> super::source::Initializer for PollingInitializer<T> {
     fn run(&mut self) -> futures::future::BoxFuture<'_, FDv2SourceEvent> {
         Box::pin(async move {
-            let request = match build_poll_request(
-                &self.base_url,
-                &self.sdk_key,
-                &self.selector,
-                self.filter_key.as_deref(),
-            ) {
+            let request = match build_poll_request(&self.base_url, &self.sdk_key, &self.selector) {
                 Ok(r) => r,
                 Err(e) => {
                     return FDv2SourceEvent {
@@ -235,7 +222,6 @@ pub(crate) struct PollingSynchronizer<T: HttpTransport> {
     transport: T,
     base_url: String,
     sdk_key: String,
-    filter_key: Option<String>,
     poll_interval: Duration,
     last_poll_start: Option<std::time::Instant>,
 }
@@ -245,14 +231,12 @@ impl<T: HttpTransport> PollingSynchronizer<T> {
         transport: T,
         base_url: String,
         sdk_key: String,
-        filter_key: Option<String>,
         poll_interval: Duration,
     ) -> Self {
         Self {
             transport,
             base_url,
             sdk_key,
-            filter_key,
             poll_interval: std::cmp::max(poll_interval, MINIMUM_POLL_INTERVAL),
             last_poll_start: None,
         }
@@ -273,12 +257,7 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
             self.last_poll_start = Some(std::time::Instant::now());
 
             // Build the poll request.
-            let request = match build_poll_request(
-                &self.base_url,
-                &self.sdk_key,
-                &selector,
-                self.filter_key.as_deref(),
-            ) {
+            let request = match build_poll_request(&self.base_url, &self.sdk_key, &selector) {
                 Ok(r) => r,
                 Err(e) => {
                     return FDv2SourceEvent {
@@ -305,9 +284,8 @@ fn build_poll_request(
     base_url: &str,
     sdk_key: &str,
     selector: &Selector,
-    filter_key: Option<&str>,
 ) -> Result<Request<Option<Bytes>>, http::Error> {
-    let url = build_fdv2_url(base_url, "sdk/poll", selector, filter_key);
+    let url = build_fdv2_url(base_url, "sdk/poll", selector);
     Request::builder()
         .uri(url)
         .method("GET")
@@ -542,7 +520,6 @@ mod tests {
             "http://example.com".to_string(),
             "sdk-key".to_string(),
             Some("stored-state".to_string()),
-            None,
         );
         let _ = initializer.run().await;
         let uri = captured.lock().unwrap().clone().expect("uri captured");
@@ -560,7 +537,6 @@ mod tests {
             transport,
             "http://example.com".to_string(),
             "sdk-key".to_string(),
-            None,
             Duration::ZERO,
         );
         let _ = sync.next(Some("per-call-state".to_string())).await;
@@ -595,7 +571,6 @@ mod tests {
             },
             "http://example.com".to_string(),
             "sdk-key".to_string(),
-            None,
             Duration::from_secs(60),
         );
 
@@ -626,7 +601,6 @@ mod tests {
             },
             "http://example.com".to_string(),
             "sdk-key".to_string(),
-            None,
             Duration::from_secs(1),
         );
 
@@ -647,7 +621,7 @@ mod tests {
     #[tokio::test]
     async fn network_error_returns_interrupted_without_fallback() {
         let transport = FailingTransport;
-        let req = build_poll_request("http://example.com", "sdk-key", &None, None).unwrap();
+        let req = build_poll_request("http://example.com", "sdk-key", &None).unwrap();
         let event = fetch_and_handle(&transport, req).await;
         let FDv2SourceResult::Interrupted(err) = event.result else {
             panic!("expected Interrupted");
@@ -705,13 +679,8 @@ mod tests {
 
         let transport = launchdarkly_sdk_transport::HyperTransport::new().expect("hyper transport");
         use super::super::source::Synchronizer;
-        let mut sync = PollingSynchronizer::new(
-            transport,
-            server.url(),
-            "sdk-key".into(),
-            None,
-            Duration::ZERO,
-        );
+        let mut sync =
+            PollingSynchronizer::new(transport, server.url(), "sdk-key".into(), Duration::ZERO);
 
         let out = sync.next(None).await;
         let FDv2SourceResult::ChangeSet(cs) = out.result else {

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -4,60 +4,18 @@ use bytes::Bytes;
 use futures::StreamExt;
 use http::{HeaderMap, Request, Response, StatusCode};
 use launchdarkly_sdk_transport::{ByteStream, HttpTransport};
-use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use serde::Deserialize;
 
 use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::source::{ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult};
+use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
 use crate::stores::change_set::ChangeSet;
 
 const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
 const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
 const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
-
-/// Percent-encoding set for URL query values: encodes everything except
-/// RFC 3986 unreserved characters (A-Za-z0-9 and `- . _ ~`).
-const QUERY_VALUE: &AsciiSet = &NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~');
-
-fn is_valid_filter_key(k: &str) -> bool {
-    let mut chars = k.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !first.is_ascii_alphanumeric() {
-        return false;
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
-}
-
-fn build_poll_url(base_url: &str, selector: &Selector, filter_key: Option<&str>) -> String {
-    let trimmed = base_url.trim_end_matches('/');
-    let mut url = format!("{trimmed}/sdk/poll");
-
-    let mut sep = '?';
-    if let Some(state) = selector.as_deref() {
-        url.push(sep);
-        url.push_str("basis=");
-        url.push_str(&utf8_percent_encode(state, QUERY_VALUE).to_string());
-        sep = '&';
-    }
-    if let Some(filter) = filter_key {
-        if is_valid_filter_key(filter) {
-            url.push(sep);
-            url.push_str("filter=");
-            url.push_str(&utf8_percent_encode(filter, QUERY_VALUE).to_string());
-        } else {
-            warn!("data source config: filter key '{filter}' is invalid, requesting full environment instead");
-        }
-    }
-    url
-}
 
 fn interrupted(kind: ErrorKind, message: impl Into<String>) -> FDv2SourceEvent {
     FDv2SourceEvent {
@@ -361,7 +319,7 @@ fn build_poll_request(
     selector: &Selector,
     filter_key: Option<&str>,
 ) -> Result<Request<Option<Bytes>>, http::Error> {
-    let url = build_poll_url(base_url, selector, filter_key);
+    let url = build_fdv2_url(base_url, "sdk/poll", selector, filter_key);
     Request::builder()
         .uri(url)
         .method("GET")
@@ -374,48 +332,6 @@ fn build_poll_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn base_with_subpath_trailing_slash_joins_cleanly() {
-        let url = build_poll_url("http://example.com/relay/", &None, None);
-        assert_eq!(url, "http://example.com/relay/sdk/poll");
-    }
-
-    #[test]
-    fn valid_filter_key_is_included() {
-        let url = build_poll_url("http://example.com", &None, Some("my-filter_1.0"));
-        assert_eq!(url, "http://example.com/sdk/poll?filter=my-filter_1.0");
-    }
-
-    #[test]
-    fn invalid_filter_key_is_dropped() {
-        let url = build_poll_url("http://example.com", &None, Some("has spaces"));
-        assert_eq!(url, "http://example.com/sdk/poll");
-    }
-
-    #[test]
-    fn selector_state_is_percent_encoded() {
-        let selector = Some("a&b".to_string());
-        let url = build_poll_url("http://example.com", &selector, None);
-        assert_eq!(url, "http://example.com/sdk/poll?basis=a%26b");
-    }
-
-    #[test]
-    fn selector_with_reserved_chars_is_encoded() {
-        let selector = Some("(p:abc:52)".to_string());
-        let url = build_poll_url("http://example.com", &selector, None);
-        assert_eq!(url, "http://example.com/sdk/poll?basis=%28p%3Aabc%3A52%29");
-    }
-
-    #[test]
-    fn selector_and_filter_both_included() {
-        let selector = Some("state-1".to_string());
-        let url = build_poll_url("http://example.com", &selector, Some("my-filter"));
-        assert_eq!(
-            url,
-            "http://example.com/sdk/poll?basis=state-1&filter=my-filter"
-        );
-    }
 
     fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
         let mut h = HeaderMap::new();

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -71,8 +71,11 @@ fn parse_poll_body(body: &[u8]) -> FDv2SourceEvent {
                 }
             },
             ProtocolResult::Goodbye(g) => {
+                if let Some(reason) = &g.reason {
+                    info!("FDv2 polling source received goodbye: {reason}");
+                }
                 return FDv2SourceEvent {
-                    result: FDv2SourceResult::Goodbye { reason: g.reason },
+                    result: FDv2SourceResult::Goodbye,
                     fdv1_fallback: g.protocol_fallback_ttl.map(|s| FDv1FallbackDirective {
                         ttl: Duration::from_secs(s),
                     }),
@@ -653,10 +656,7 @@ mod tests {
         });
         let body = serde_json::to_vec(&envelope).unwrap();
         let event = parse_poll_body(&body);
-        let FDv2SourceResult::Goodbye { reason } = event.result else {
-            panic!("expected Goodbye");
-        };
-        assert_eq!(reason.as_deref(), Some("rotating"));
+        assert!(matches!(event.result, FDv2SourceResult::Goodbye));
         assert_eq!(
             event.fdv1_fallback.as_ref().map(|d| d.ttl),
             Some(Duration::from_secs(90))

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -1,0 +1,788 @@
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use http::{HeaderMap, Request, Response, StatusCode};
+use launchdarkly_sdk_transport::{ByteStream, HttpTransport};
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use serde::Deserialize;
+
+use super::model::{ChangeSetKind, Selector};
+use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
+use super::source::{ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult};
+use crate::reqwest::is_http_error_recoverable;
+use crate::stores::change_set::ChangeSet;
+
+const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
+const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
+const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Percent-encoding set for URL query values: encodes everything except
+/// RFC 3986 unreserved characters (A-Za-z0-9 and `- . _ ~`).
+const QUERY_VALUE: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+fn is_valid_filter_key(k: &str) -> bool {
+    let mut chars = k.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+fn build_poll_url(base_url: &str, selector: &Selector, filter_key: Option<&str>) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    let mut url = format!("{trimmed}/sdk/poll");
+
+    let mut sep = '?';
+    if let Some(state) = selector.as_deref() {
+        url.push(sep);
+        url.push_str("basis=");
+        url.push_str(&utf8_percent_encode(state, QUERY_VALUE).to_string());
+        sep = '&';
+    }
+    if let Some(filter) = filter_key {
+        if is_valid_filter_key(filter) {
+            url.push(sep);
+            url.push_str("filter=");
+            url.push_str(&utf8_percent_encode(filter, QUERY_VALUE).to_string());
+        } else {
+            warn!("data source config: filter key '{filter}' is invalid, requesting full environment instead");
+        }
+    }
+    url
+}
+
+fn interrupted(kind: ErrorKind, message: impl Into<String>) -> FDv2SourceEvent {
+    FDv2SourceEvent {
+        result: FDv2SourceResult::Interrupted(ErrorInfo {
+            kind,
+            message: message.into(),
+        }),
+        fdv1_fallback: None,
+    }
+}
+
+#[derive(Deserialize)]
+struct PollEnvelope {
+    events: Vec<PollEvent>,
+}
+
+#[derive(Deserialize)]
+struct PollEvent {
+    event: String,
+    data: serde_json::Value,
+}
+
+fn parse_poll_body(body: &[u8]) -> FDv2SourceEvent {
+    let envelope: PollEnvelope = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => {
+            return interrupted(ErrorKind::InvalidData, "could not parse FDv2 polling response");
+        }
+    };
+
+    let mut handler = FDv2ProtocolHandler::new();
+    for event in envelope.events {
+        match handler.handle_event(&event.event, event.data) {
+            ProtocolResult::None => continue,
+            ProtocolResult::ChangeSet(wire_cs) => match ChangeSet::try_from(wire_cs) {
+                Ok(cs) => {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::ChangeSet(cs),
+                        fdv1_fallback: None,
+                    };
+                }
+                Err(_) => {
+                    return interrupted(
+                        ErrorKind::InvalidData,
+                        "FDv2 polling response could not be translated",
+                    );
+                }
+            },
+            ProtocolResult::Goodbye(g) => {
+                return FDv2SourceEvent {
+                    result: FDv2SourceResult::Goodbye { reason: g.reason },
+                    fdv1_fallback: g.protocol_fallback_ttl.map(|s| FDv1FallbackDirective {
+                        ttl: Duration::from_secs(s),
+                    }),
+                };
+            }
+            ProtocolResult::Error(ProtocolError::Server(err)) => {
+                let msg = format!(
+                    "An issue was encountered receiving updates for payload '{}' with reason: '{}'. Automatic retry will occur.",
+                    err.id.as_deref().unwrap_or(""),
+                    err.reason,
+                );
+                return interrupted(ErrorKind::ErrorResponse { status_code: 0 }, msg);
+            }
+            ProtocolResult::Error(ProtocolError::Protocol(msg))
+            | ProtocolResult::Error(ProtocolError::JsonParse(msg)) => {
+                return interrupted(ErrorKind::InvalidData, msg);
+            }
+        }
+    }
+    interrupted(
+        ErrorKind::InvalidData,
+        "FDv2 polling response did not contain a complete payload",
+    )
+}
+
+async fn handle_response(response: Response<ByteStream>) -> FDv2SourceEvent {
+    let fallback = read_fallback_directive(response.headers());
+    let status = response.status();
+
+    if status == StatusCode::NOT_MODIFIED {
+        return FDv2SourceEvent {
+            result: FDv2SourceResult::ChangeSet(ChangeSet {
+                kind: ChangeSetKind::None,
+                changes: Vec::new(),
+                selector: None,
+            }),
+            fdv1_fallback: fallback,
+        };
+    }
+
+    if status.is_success() {
+        let mut body_bytes = Vec::new();
+        let mut stream = response.into_body();
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(b) => body_bytes.extend_from_slice(&b),
+                Err(e) => {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::Interrupted(ErrorInfo {
+                            kind: ErrorKind::NetworkError,
+                            message: format!("could not read polling response body: {e}"),
+                        }),
+                        fdv1_fallback: fallback,
+                    };
+                }
+            }
+        }
+        if body_bytes.is_empty() {
+            return FDv2SourceEvent {
+                result: FDv2SourceResult::Interrupted(ErrorInfo {
+                    kind: ErrorKind::InvalidData,
+                    message: "polling response contained no body".into(),
+                }),
+                fdv1_fallback: fallback,
+            };
+        }
+        let mut event = parse_poll_body(&body_bytes);
+        if event.fdv1_fallback.is_none() {
+            event.fdv1_fallback = fallback;
+        }
+        return event;
+    }
+
+    let status_u16 = status.as_u16();
+    let message = format!("FDv2 polling request received HTTP status {status_u16}");
+    let error_info = ErrorInfo {
+        kind: ErrorKind::ErrorResponse {
+            status_code: status_u16,
+        },
+        message,
+    };
+    if is_http_error_recoverable(status_u16) {
+        FDv2SourceEvent {
+            result: FDv2SourceResult::Interrupted(error_info),
+            fdv1_fallback: fallback,
+        }
+    } else {
+        FDv2SourceEvent {
+            result: FDv2SourceResult::TerminalError(error_info),
+            fdv1_fallback: fallback,
+        }
+    }
+}
+
+async fn fetch_and_handle<T: HttpTransport>(
+    transport: &T,
+    request: Request<Option<Bytes>>,
+) -> FDv2SourceEvent {
+    match transport.request(request).await {
+        Ok(response) => handle_response(response).await,
+        Err(e) => interrupted(ErrorKind::NetworkError, format!("{e}")),
+    }
+}
+
+pub(crate) struct PollingInitializer<T: HttpTransport> {
+    transport: T,
+    base_url: String,
+    sdk_key: String,
+    selector: Selector,
+    filter_key: Option<String>,
+}
+
+impl<T: HttpTransport> PollingInitializer<T> {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        sdk_key: String,
+        selector: Selector,
+        filter_key: Option<String>,
+    ) -> Self {
+        Self {
+            transport,
+            base_url,
+            sdk_key,
+            selector,
+            filter_key,
+        }
+    }
+}
+
+impl<T: HttpTransport> super::source::Initializer for PollingInitializer<T> {
+    fn run(&mut self) -> futures::future::BoxFuture<'_, FDv2SourceEvent> {
+        Box::pin(async move {
+            let request = match build_poll_request(
+                &self.base_url,
+                &self.sdk_key,
+                &self.selector,
+                self.filter_key.as_deref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::TerminalError(ErrorInfo {
+                            kind: ErrorKind::Unknown,
+                            message: format!("could not build polling request: {e}"),
+                        }),
+                        fdv1_fallback: None,
+                    };
+                }
+            };
+            fetch_and_handle(&self.transport, request).await
+        })
+    }
+
+    fn name(&self) -> &str {
+        "FDv2 polling initializer"
+    }
+}
+
+pub(crate) struct PollingSynchronizer<T: HttpTransport> {
+    transport: T,
+    base_url: String,
+    sdk_key: String,
+    filter_key: Option<String>,
+    poll_interval: Duration,
+    last_poll_start: std::sync::Arc<parking_lot::Mutex<Option<std::time::Instant>>>,
+}
+
+impl<T: HttpTransport> PollingSynchronizer<T> {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        sdk_key: String,
+        filter_key: Option<String>,
+        poll_interval: Duration,
+    ) -> Self {
+        Self {
+            transport,
+            base_url,
+            sdk_key,
+            filter_key,
+            poll_interval,
+            last_poll_start: std::sync::Arc::new(parking_lot::Mutex::new(None)),
+        }
+    }
+}
+
+impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
+    fn next(&mut self, selector: Selector) -> futures::future::BoxFuture<'_, FDv2SourceEvent> {
+        Box::pin(async move {
+            // Wait for the poll interval to elapse since the previous request.
+            let wait = {
+                let last = self.last_poll_start.lock();
+                match *last {
+                    Some(t) => self.poll_interval.saturating_sub(t.elapsed()),
+                    None => Duration::ZERO,
+                }
+            };
+            if !wait.is_zero() {
+                tokio::time::sleep(wait).await;
+            }
+            *self.last_poll_start.lock() = Some(std::time::Instant::now());
+
+            // Build the poll request.
+            let request = match build_poll_request(
+                &self.base_url,
+                &self.sdk_key,
+                &selector,
+                self.filter_key.as_deref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::TerminalError(ErrorInfo {
+                            kind: ErrorKind::Unknown,
+                            message: format!("could not build polling request: {e}"),
+                        }),
+                        fdv1_fallback: None,
+                    };
+                }
+            };
+
+            // Fire it and interpret the response.
+            fetch_and_handle(&self.transport, request).await
+        })
+    }
+
+    fn name(&self) -> &str {
+        "FDv2 polling synchronizer"
+    }
+}
+
+fn read_fallback_directive(headers: &HeaderMap) -> Option<FDv1FallbackDirective> {
+    let flag = headers.get(FALLBACK_HEADER)?;
+    if !flag.to_str().is_ok_and(|s| s.eq_ignore_ascii_case("true")) {
+        return None;
+    }
+    let ttl = headers
+        .get(FALLBACK_TTL_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_FALLBACK_TTL);
+    Some(FDv1FallbackDirective { ttl })
+}
+
+fn build_poll_request(
+    base_url: &str,
+    sdk_key: &str,
+    selector: &Selector,
+    filter_key: Option<&str>,
+) -> Result<Request<Option<Bytes>>, http::Error> {
+    let url = build_poll_url(base_url, selector, filter_key);
+    Request::builder()
+        .uri(url)
+        .method("GET")
+        .header("Content-Type", "application/json")
+        .header("Authorization", sdk_key)
+        .header("User-Agent", &*crate::USER_AGENT)
+        .body(Some(Bytes::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_with_subpath_trailing_slash_joins_cleanly() {
+        let url = build_poll_url("http://example.com/relay/", &None, None);
+        assert_eq!(url, "http://example.com/relay/sdk/poll");
+    }
+
+    #[test]
+    fn valid_filter_key_is_included() {
+        let url = build_poll_url("http://example.com", &None, Some("my-filter_1.0"));
+        assert_eq!(url, "http://example.com/sdk/poll?filter=my-filter_1.0");
+    }
+
+    #[test]
+    fn invalid_filter_key_is_dropped() {
+        let url = build_poll_url("http://example.com", &None, Some("has spaces"));
+        assert_eq!(url, "http://example.com/sdk/poll");
+    }
+
+    #[test]
+    fn selector_state_is_percent_encoded() {
+        let selector = Some("a&b".to_string());
+        let url = build_poll_url("http://example.com", &selector, None);
+        assert_eq!(url, "http://example.com/sdk/poll?basis=a%26b");
+    }
+
+    #[test]
+    fn selector_with_reserved_chars_is_encoded() {
+        let selector = Some("(p:abc:52)".to_string());
+        let url = build_poll_url("http://example.com", &selector, None);
+        assert_eq!(url, "http://example.com/sdk/poll?basis=%28p%3Aabc%3A52%29");
+    }
+
+    #[test]
+    fn selector_and_filter_both_included() {
+        let selector = Some("state-1".to_string());
+        let url = build_poll_url("http://example.com", &selector, Some("my-filter"));
+        assert_eq!(
+            url,
+            "http://example.com/sdk/poll?basis=state-1&filter=my-filter"
+        );
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                http::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn fallback_absent_header_returns_none() {
+        assert!(read_fallback_directive(&HeaderMap::new()).is_none());
+    }
+
+    #[test]
+    fn fallback_header_value_other_than_true_returns_none() {
+        let h = headers(&[("X-LD-FD-Fallback", "false")]);
+        assert!(read_fallback_directive(&h).is_none());
+    }
+
+    #[test]
+    fn fallback_header_uppercase_true_uses_default_ttl() {
+        let h = headers(&[("X-LD-FD-Fallback", "TRUE")]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+    }
+
+    #[test]
+    fn fallback_ttl_header_is_parsed() {
+        let h = headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "60"),
+        ]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn fallback_ttl_header_malformed_uses_default() {
+        let h = headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "not-a-number"),
+        ]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+    }
+
+    fn full_payload_body(flag_key: &str) -> Vec<u8> {
+        let flag = crate::test_common::basic_flag(flag_key);
+        let flag_json = serde_json::to_value(&flag).unwrap();
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "server-intent", "data": {"payloads": [{
+                    "id": "p1",
+                    "target": 1,
+                    "intentCode": "xfer-full",
+                    "reason": "payload-missing",
+                }]}},
+                {"event": "put-object", "data": {
+                    "version": 1,
+                    "kind": "flag",
+                    "key": flag_key,
+                    "object": flag_json,
+                }},
+                {"event": "payload-transferred", "data": {"state": "s-1"}},
+            ]
+        });
+        serde_json::to_vec(&envelope).unwrap()
+    }
+
+    #[test]
+    fn parse_full_payload_returns_change_set() {
+        let body = full_payload_body("my-flag");
+        let event = parse_poll_body(&body);
+        let FDv2SourceResult::ChangeSet(cs) = event.result else {
+            panic!("expected ChangeSet, got {:?}", event.result);
+        };
+        assert_eq!(cs.changes.len(), 1);
+        assert_eq!(cs.selector.as_deref(), Some("s-1"));
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_interrupted() {
+        let event = parse_poll_body(b"not json");
+        assert!(matches!(
+            event.result,
+            FDv2SourceResult::Interrupted(ErrorInfo {
+                kind: ErrorKind::InvalidData,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_incomplete_payload_returns_interrupted() {
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "server-intent", "data": {"payloads": [{
+                    "id": "p1",
+                    "target": 1,
+                    "intentCode": "xfer-full",
+                    "reason": "payload-missing",
+                }]}},
+            ]
+        });
+        let body = serde_json::to_vec(&envelope).unwrap();
+        let event = parse_poll_body(&body);
+        let FDv2SourceResult::Interrupted(err) = event.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+        assert!(err.message.contains("complete"), "message: {}", err.message);
+    }
+
+    #[test]
+    fn parse_translator_failure_returns_interrupted() {
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "server-intent", "data": {"payloads": [{
+                    "id": "p1",
+                    "target": 1,
+                    "intentCode": "xfer-full",
+                    "reason": "payload-missing",
+                }]}},
+                {"event": "put-object", "data": {
+                    "version": 1,
+                    "kind": "flag",
+                    "key": "bad",
+                    "object": {"garbage": true},
+                }},
+                {"event": "payload-transferred", "data": {"state": "s-1"}},
+            ]
+        });
+        let body = serde_json::to_vec(&envelope).unwrap();
+        let event = parse_poll_body(&body);
+        let FDv2SourceResult::Interrupted(err) = event.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+        assert!(err.message.contains("translated"), "message: {}", err.message);
+    }
+
+    fn make_response(status: u16, headers: &[(&str, &str)], body: &[u8]) -> Response<ByteStream> {
+        let mut builder = Response::builder().status(status);
+        for (k, v) in headers {
+            builder = builder.header(*k, *v);
+        }
+        let body = body.to_vec();
+        let stream = futures::stream::iter(vec![Ok(Bytes::from(body))]);
+        builder.body(Box::pin(stream) as ByteStream).unwrap()
+    }
+
+    #[tokio::test]
+    async fn handle_304_with_header_returns_none_changeset_with_fallback() {
+        let resp = make_response(304, &[("X-LD-FD-Fallback", "true")], &[]);
+        let event = handle_response(resp).await;
+        let FDv2SourceResult::ChangeSet(cs) = event.result else {
+            panic!("expected ChangeSet");
+        };
+        assert_eq!(cs.kind, ChangeSetKind::None);
+        assert!(event.fdv1_fallback.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_recoverable_status_returns_interrupted_with_fallback() {
+        let resp = make_response(400, &[("X-LD-FD-Fallback", "true")], &[]);
+        let event = handle_response(resp).await;
+        let FDv2SourceResult::Interrupted(err) = event.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::ErrorResponse { status_code: 400 });
+        assert!(event.fdv1_fallback.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_terminal_status_returns_terminal_error_with_fallback() {
+        let resp = make_response(401, &[("X-LD-FD-Fallback", "true")], &[]);
+        let event = handle_response(resp).await;
+        let FDv2SourceResult::TerminalError(err) = event.result else {
+            panic!("expected TerminalError");
+        };
+        assert_eq!(err.kind, ErrorKind::ErrorResponse { status_code: 401 });
+        assert!(event.fdv1_fallback.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_200_with_valid_body_returns_change_set() {
+        let body = full_payload_body("my-flag");
+        let resp = make_response(200, &[("X-LD-FD-Fallback", "true")], &body);
+        let event = handle_response(resp).await;
+        assert!(matches!(event.result, FDv2SourceResult::ChangeSet(_)));
+        assert!(event.fdv1_fallback.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_200_with_empty_body_returns_interrupted() {
+        let resp = make_response(200, &[], &[]);
+        let event = handle_response(resp).await;
+        let FDv2SourceResult::Interrupted(err) = event.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn in_body_fallback_takes_precedence_over_header() {
+        // Envelope with a goodbye event carrying protocolFallbackTTL=90, plus a
+        // header saying fallback with default (3600) TTL. Body wins.
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "goodbye", "data": {"protocolFallbackTTL": 90}},
+            ]
+        });
+        let body = serde_json::to_vec(&envelope).unwrap();
+        let resp = make_response(200, &[("X-LD-FD-Fallback", "true")], &body);
+        let event = handle_response(resp).await;
+        assert_eq!(
+            event.fdv1_fallback.as_ref().map(|d| d.ttl),
+            Some(Duration::from_secs(90))
+        );
+    }
+
+    #[derive(Clone)]
+    struct FailingTransport;
+    impl HttpTransport for FailingTransport {
+        fn request(
+            &self,
+            _request: Request<Option<Bytes>>,
+        ) -> launchdarkly_sdk_transport::ResponseFuture {
+            Box::pin(async {
+                Err(launchdarkly_sdk_transport::TransportError::new(
+                    std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "boom"),
+                ))
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct CapturingTransport {
+        captured_uri: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    impl HttpTransport for CapturingTransport {
+        fn request(
+            &self,
+            request: Request<Option<Bytes>>,
+        ) -> launchdarkly_sdk_transport::ResponseFuture {
+            *self.captured_uri.lock().unwrap() = Some(request.uri().to_string());
+            Box::pin(async { Ok(make_response(200, &[], b"{\"events\":[]}")) })
+        }
+    }
+
+    #[tokio::test]
+    async fn initializer_run_passes_stored_selector_in_request_url() {
+        use super::super::source::Initializer;
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let transport = CapturingTransport {
+            captured_uri: captured.clone(),
+        };
+        let mut initializer = PollingInitializer::new(
+            transport,
+            "http://example.com".to_string(),
+            "sdk-key".to_string(),
+            Some("stored-state".to_string()),
+            None,
+        );
+        let _ = initializer.run().await;
+        let uri = captured.lock().unwrap().clone().expect("uri captured");
+        assert!(uri.contains("basis=stored-state"), "uri: {uri}");
+    }
+
+    #[tokio::test]
+    async fn synchronizer_next_uses_argument_selector() {
+        use super::super::source::Synchronizer;
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let transport = CapturingTransport {
+            captured_uri: captured.clone(),
+        };
+        let mut sync = PollingSynchronizer::new(
+            transport,
+            "http://example.com".to_string(),
+            "sdk-key".to_string(),
+            None,
+            Duration::ZERO,
+        );
+        let _ = sync.next(Some("per-call-state".to_string())).await;
+        let uri = captured.lock().unwrap().clone().expect("uri captured");
+        assert!(uri.contains("basis=per-call-state"), "uri: {uri}");
+    }
+
+    #[derive(Clone)]
+    struct CountingTransport {
+        count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl HttpTransport for CountingTransport {
+        fn request(
+            &self,
+            _request: Request<Option<Bytes>>,
+        ) -> launchdarkly_sdk_transport::ResponseFuture {
+            self.count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async { Ok(make_response(200, &[], b"{\"events\":[]}")) })
+        }
+    }
+
+    #[tokio::test]
+    async fn synchronizer_next_enforces_poll_interval() {
+        use super::super::source::Synchronizer;
+        use std::sync::atomic::Ordering;
+        let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let transport = CountingTransport {
+            count: count.clone(),
+        };
+        let mut sync = PollingSynchronizer::new(
+            transport,
+            "http://example.com".to_string(),
+            "sdk-key".to_string(),
+            None,
+            Duration::from_millis(50),
+        );
+
+        let start = std::time::Instant::now();
+        let _ = sync.next(None).await;
+        let _ = sync.next(None).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            elapsed >= Duration::from_millis(45),
+            "expected the second poll to wait ~50ms, got total {elapsed:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn network_error_returns_interrupted_without_fallback() {
+        let transport = FailingTransport;
+        let req = build_poll_request("http://example.com", "sdk-key", &None, None).unwrap();
+        let event = fetch_and_handle(&transport, req).await;
+        let FDv2SourceResult::Interrupted(err) = event.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::NetworkError);
+        assert!(event.fdv1_fallback.is_none());
+    }
+
+    #[test]
+    fn parse_goodbye_event_returns_goodbye_with_fallback() {
+        let envelope = serde_json::json!({
+            "events": [
+                {"event": "goodbye", "data": {
+                    "reason": "rotating",
+                    "protocolFallbackTTL": 90,
+                }},
+            ]
+        });
+        let body = serde_json::to_vec(&envelope).unwrap();
+        let event = parse_poll_body(&body);
+        let FDv2SourceResult::Goodbye { reason } = event.result else {
+            panic!("expected Goodbye");
+        };
+        assert_eq!(reason.as_deref(), Some("rotating"));
+        assert_eq!(
+            event.fdv1_fallback.as_ref().map(|d| d.ttl),
+            Some(Duration::from_secs(90))
+        );
+    }
+}

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -8,9 +8,10 @@ use serde::Deserialize;
 
 use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
+use super::request_headers::RequestHeaders;
 use super::source::{
     read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
-    FDv2SourceResult, RequestHeaders,
+    FDv2SourceResult,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;

--- a/launchdarkly-server-sdk/src/fdv2/request_headers.rs
+++ b/launchdarkly-server-sdk/src/fdv2/request_headers.rs
@@ -1,0 +1,28 @@
+/// The HTTP headers attached to every FDv2 request.
+#[derive(Clone)]
+pub(crate) struct RequestHeaders {
+    headers: Vec<(&'static str, String)>,
+}
+
+impl RequestHeaders {
+    pub(crate) fn new(sdk_key: &str, tags: Option<&str>, instance_id: &str) -> Self {
+        let mut headers = vec![
+            ("Authorization", sdk_key.to_string()),
+            ("User-Agent", crate::USER_AGENT.clone()),
+            (
+                crate::LAUNCHDARKLY_INSTANCE_ID_HEADER,
+                instance_id.to_string(),
+            ),
+        ];
+        if let Some(tags) = tags {
+            headers.push((crate::LAUNCHDARKLY_TAGS_HEADER, tags.to_string()));
+        }
+        Self { headers }
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&'static str, &str)> + '_ {
+        self.headers
+            .iter()
+            .map(|(name, value)| (*name, value.as_str()))
+    }
+}

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -1,10 +1,15 @@
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use http::HeaderMap;
 
 use crate::stores::change_set::ChangeSet;
 
 use super::model::Selector;
+
+pub(super) const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
+pub(super) const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
+pub(super) const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ErrorKind {
@@ -24,6 +29,20 @@ pub(crate) struct ErrorInfo {
 #[derive(Debug)]
 pub(crate) struct FDv1FallbackDirective {
     pub(crate) ttl: Duration,
+}
+
+pub(super) fn read_fallback_directive(headers: &HeaderMap) -> Option<FDv1FallbackDirective> {
+    let flag = headers.get(FALLBACK_HEADER)?;
+    if !flag.to_str().is_ok_and(|s| s.eq_ignore_ascii_case("true")) {
+        return None;
+    }
+    let ttl = headers
+        .get(FALLBACK_TTL_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_FALLBACK_TTL);
+    Some(FDv1FallbackDirective { ttl })
 }
 
 #[derive(Debug)]
@@ -49,4 +68,55 @@ pub(crate) trait Initializer: Send {
 pub(crate) trait Synchronizer: Send {
     fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent>;
     fn name(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                http::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn fallback_absent_header_returns_none() {
+        assert!(read_fallback_directive(&HeaderMap::new()).is_none());
+    }
+
+    #[test]
+    fn fallback_header_value_other_than_true_returns_none() {
+        let h = headers(&[("X-LD-FD-Fallback", "false")]);
+        assert!(read_fallback_directive(&h).is_none());
+    }
+
+    #[test]
+    fn fallback_header_uppercase_true_uses_default_ttl() {
+        let h = headers(&[("X-LD-FD-Fallback", "TRUE")]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+    }
+
+    #[test]
+    fn fallback_ttl_header_is_parsed() {
+        let h = headers(&[("X-LD-FD-Fallback", "true"), ("X-LD-FD-Fallback-TTL", "60")]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn fallback_ttl_header_malformed_uses_default() {
+        let h = headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "not-a-number"),
+        ]);
+        let d = read_fallback_directive(&h).expect("directive");
+        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+    }
 }

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -11,6 +11,35 @@ pub(super) const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
 pub(super) const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
 pub(super) const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
+/// The HTTP headers attached to every FDv2 request.
+#[derive(Clone)]
+pub(crate) struct RequestHeaders {
+    headers: Vec<(&'static str, String)>,
+}
+
+impl RequestHeaders {
+    pub(crate) fn new(sdk_key: &str, tags: Option<&str>, instance_id: &str) -> Self {
+        let mut headers = vec![
+            ("Authorization", sdk_key.to_string()),
+            ("User-Agent", crate::USER_AGENT.clone()),
+            (
+                crate::LAUNCHDARKLY_INSTANCE_ID_HEADER,
+                instance_id.to_string(),
+            ),
+        ];
+        if let Some(tags) = tags {
+            headers.push((crate::LAUNCHDARKLY_TAGS_HEADER, tags.to_string()));
+        }
+        Self { headers }
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&'static str, &str)> + '_ {
+        self.headers
+            .iter()
+            .map(|(name, value)| (*name, value.as_str()))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ErrorKind {
     Unknown,

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -11,35 +11,6 @@ pub(super) const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
 pub(super) const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
 pub(super) const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
-/// The HTTP headers attached to every FDv2 request.
-#[derive(Clone)]
-pub(crate) struct RequestHeaders {
-    headers: Vec<(&'static str, String)>,
-}
-
-impl RequestHeaders {
-    pub(crate) fn new(sdk_key: &str, tags: Option<&str>, instance_id: &str) -> Self {
-        let mut headers = vec![
-            ("Authorization", sdk_key.to_string()),
-            ("User-Agent", crate::USER_AGENT.clone()),
-            (
-                crate::LAUNCHDARKLY_INSTANCE_ID_HEADER,
-                instance_id.to_string(),
-            ),
-        ];
-        if let Some(tags) = tags {
-            headers.push((crate::LAUNCHDARKLY_TAGS_HEADER, tags.to_string()));
-        }
-        Self { headers }
-    }
-
-    pub(super) fn iter(&self) -> impl Iterator<Item = (&'static str, &str)> + '_ {
-        self.headers
-            .iter()
-            .map(|(name, value)| (*name, value.as_str()))
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ErrorKind {
     Unknown,

--- a/launchdarkly-server-sdk/src/fdv2/url.rs
+++ b/launchdarkly-server-sdk/src/fdv2/url.rs
@@ -1,0 +1,113 @@
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+use super::model::Selector;
+
+/// Percent-encoding set for URL query values: encodes everything except
+/// RFC 3986 unreserved characters (A-Za-z0-9 and `- . _ ~`).
+const QUERY_VALUE: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+pub(super) fn is_valid_filter_key(k: &str) -> bool {
+    let mut chars = k.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+pub(super) fn build_fdv2_url(
+    base_url: &str,
+    endpoint_path: &str,
+    selector: &Selector,
+    filter_key: Option<&str>,
+) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    let mut url = format!("{trimmed}/{endpoint_path}");
+
+    let mut sep = '?';
+    if let Some(state) = selector.as_deref() {
+        url.push(sep);
+        url.push_str("basis=");
+        url.push_str(&utf8_percent_encode(state, QUERY_VALUE).to_string());
+        sep = '&';
+    }
+    if let Some(filter) = filter_key {
+        if is_valid_filter_key(filter) {
+            url.push(sep);
+            url.push_str("filter=");
+            url.push_str(&utf8_percent_encode(filter, QUERY_VALUE).to_string());
+        } else {
+            warn!("data source config: filter key '{filter}' is invalid, requesting full environment instead");
+        }
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_with_subpath_trailing_slash_joins_cleanly() {
+        let url = build_fdv2_url("http://example.com/relay/", "sdk/poll", &None, None);
+        assert_eq!(url, "http://example.com/relay/sdk/poll");
+    }
+
+    #[test]
+    fn endpoint_path_is_included_verbatim() {
+        let url = build_fdv2_url("http://example.com", "sdk/stream", &None, None);
+        assert_eq!(url, "http://example.com/sdk/stream");
+    }
+
+    #[test]
+    fn valid_filter_key_is_included() {
+        let url = build_fdv2_url(
+            "http://example.com",
+            "sdk/poll",
+            &None,
+            Some("my-filter_1.0"),
+        );
+        assert_eq!(url, "http://example.com/sdk/poll?filter=my-filter_1.0");
+    }
+
+    #[test]
+    fn invalid_filter_key_is_dropped() {
+        let url = build_fdv2_url("http://example.com", "sdk/poll", &None, Some("has spaces"));
+        assert_eq!(url, "http://example.com/sdk/poll");
+    }
+
+    #[test]
+    fn selector_state_is_percent_encoded() {
+        let selector = Some("a&b".to_string());
+        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector, None);
+        assert_eq!(url, "http://example.com/sdk/poll?basis=a%26b");
+    }
+
+    #[test]
+    fn selector_with_reserved_chars_is_encoded() {
+        let selector = Some("(p:abc:52)".to_string());
+        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector, None);
+        assert_eq!(url, "http://example.com/sdk/poll?basis=%28p%3Aabc%3A52%29");
+    }
+
+    #[test]
+    fn selector_and_filter_both_included() {
+        let selector = Some("state-1".to_string());
+        let url = build_fdv2_url(
+            "http://example.com",
+            "sdk/poll",
+            &selector,
+            Some("my-filter"),
+        );
+        assert_eq!(
+            url,
+            "http://example.com/sdk/poll?basis=state-1&filter=my-filter"
+        );
+    }
+}

--- a/launchdarkly-server-sdk/src/fdv2/url.rs
+++ b/launchdarkly-server-sdk/src/fdv2/url.rs
@@ -10,41 +10,13 @@ const QUERY_VALUE: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'_')
     .remove(b'~');
 
-pub(super) fn is_valid_filter_key(k: &str) -> bool {
-    let mut chars = k.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !first.is_ascii_alphanumeric() {
-        return false;
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
-}
-
-pub(super) fn build_fdv2_url(
-    base_url: &str,
-    endpoint_path: &str,
-    selector: &Selector,
-    filter_key: Option<&str>,
-) -> String {
+pub(super) fn build_fdv2_url(base_url: &str, endpoint_path: &str, selector: &Selector) -> String {
     let trimmed = base_url.trim_end_matches('/');
     let mut url = format!("{trimmed}/{endpoint_path}");
 
-    let mut sep = '?';
     if let Some(state) = selector.as_deref() {
-        url.push(sep);
-        url.push_str("basis=");
+        url.push_str("?basis=");
         url.push_str(&utf8_percent_encode(state, QUERY_VALUE).to_string());
-        sep = '&';
-    }
-    if let Some(filter) = filter_key {
-        if is_valid_filter_key(filter) {
-            url.push(sep);
-            url.push_str("filter=");
-            url.push_str(&utf8_percent_encode(filter, QUERY_VALUE).to_string());
-        } else {
-            warn!("data source config: filter key '{filter}' is invalid, requesting full environment instead");
-        }
     }
     url
 }
@@ -55,59 +27,27 @@ mod tests {
 
     #[test]
     fn base_with_subpath_trailing_slash_joins_cleanly() {
-        let url = build_fdv2_url("http://example.com/relay/", "sdk/poll", &None, None);
+        let url = build_fdv2_url("http://example.com/relay/", "sdk/poll", &None);
         assert_eq!(url, "http://example.com/relay/sdk/poll");
     }
 
     #[test]
     fn endpoint_path_is_included_verbatim() {
-        let url = build_fdv2_url("http://example.com", "sdk/stream", &None, None);
+        let url = build_fdv2_url("http://example.com", "sdk/stream", &None);
         assert_eq!(url, "http://example.com/sdk/stream");
-    }
-
-    #[test]
-    fn valid_filter_key_is_included() {
-        let url = build_fdv2_url(
-            "http://example.com",
-            "sdk/poll",
-            &None,
-            Some("my-filter_1.0"),
-        );
-        assert_eq!(url, "http://example.com/sdk/poll?filter=my-filter_1.0");
-    }
-
-    #[test]
-    fn invalid_filter_key_is_dropped() {
-        let url = build_fdv2_url("http://example.com", "sdk/poll", &None, Some("has spaces"));
-        assert_eq!(url, "http://example.com/sdk/poll");
     }
 
     #[test]
     fn selector_state_is_percent_encoded() {
         let selector = Some("a&b".to_string());
-        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector, None);
+        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector);
         assert_eq!(url, "http://example.com/sdk/poll?basis=a%26b");
     }
 
     #[test]
     fn selector_with_reserved_chars_is_encoded() {
         let selector = Some("(p:abc:52)".to_string());
-        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector, None);
+        let url = build_fdv2_url("http://example.com", "sdk/poll", &selector);
         assert_eq!(url, "http://example.com/sdk/poll?basis=%28p%3Aabc%3A52%29");
-    }
-
-    #[test]
-    fn selector_and_filter_both_included() {
-        let selector = Some("state-1".to_string());
-        let url = build_fdv2_url(
-            "http://example.com",
-            "sdk/poll",
-            &selector,
-            Some("my-filter"),
-        );
-        assert_eq!(
-            url,
-            "http://example.com/sdk/poll?basis=state-1&filter=my-filter"
-        );
     }
 }


### PR DESCRIPTION
## Summary

Adds the first concrete FDv2 sources: a polling initializer and synchronizer, both built on the existing `HttpTransport`.

A few behaviors worth noting:

- The synchronizer clamps its poll interval to a 30-second minimum.
- Requests carry the standard authentication, application tag, and instance-id headers, and send the current selector as the request basis.
- Recoverable HTTP statuses surface as interruptions and unrecoverable ones as terminal errors.

The source also reports an FDv1 fallback directive when a response signals one, which the orchestrator will act on in later work.

NOTE: This PR adds a direct dependency on `percent-encoding`, but this is low risk, because we already depend on that crate indirectly through other dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds the first concrete **FDv2 polling** sources: a `PollingInitializer` and `PollingSynchronizer` that implement the existing `Initializer` / `Synchronizer` traits over `HttpTransport`.
> 
> Poll requests go to `GET sdk/poll` with shared **RequestHeaders** (auth, user-agent, instance id, optional tags) and an optional **selector** encoded as the `basis` query parameter via new URL helpers (`percent-encoding` dependency). The synchronizer **waits between polls** and **clamps** the interval to a **30s minimum**.
> 
> Responses are mapped to `FDv2SourceEvent`: **304** yields a no-op change set; **200** bodies are parsed as FDv2 event envelopes through `FDv2ProtocolHandler`; recoverable HTTP errors become **Interrupted**, others **TerminalError**. **FDv1 fallback** directives are read from `X-LD-FD-Fallback` / TTL headers (with body precedence on goodbye), via new logic in `source.rs`.
> 
> Dev-only: `tokio` **test-util** for paused-clock interval tests; broad unit and mockito e2e coverage for parsing, status handling, selectors, and polling timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b9ff64afb0bbe8c14cda139d82b2c96baff7e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->