### PR TITLE
feat: Add the FDv2 streaming synchronizer

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -20,7 +20,7 @@ features = []
 chrono = "0.4.19"
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
-eventsource-client = { version = "0.17.0" }
+eventsource-client = { path = "../../rust-eventsource-client/eventsource-client" }
 launchdarkly-sdk-transport = { version = "0.1.0" }
 futures = "0.3.12"
 log = "0.4.14"
@@ -31,7 +31,7 @@ launchdarkly-server-sdk-evaluation = { version = "2.2.0", default-features = fal
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = { version = "1.0.73" }
 thiserror = "2.0"
-tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "sync"] }
 parking_lot = "0.12.0"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 moka = { version = "0.12.1", features = ["sync"] }

--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -20,7 +20,7 @@ features = []
 chrono = "0.4.19"
 crossbeam-channel = "0.5.1"
 data-encoding = "2.3.2"
-eventsource-client = { path = "../../rust-eventsource-client/eventsource-client" }
+eventsource-client = { version = "0.18.0" }
 launchdarkly-sdk-transport = { version = "0.1.0" }
 futures = "0.3.12"
 log = "0.4.14"

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -3,5 +3,6 @@ mod polling;
 mod protocol;
 mod request_headers;
 mod source;
+mod streaming;
 mod url;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -102,7 +102,8 @@ fn parse_poll_body(body: &[u8]) -> FDv2SourceEvent {
 }
 
 async fn handle_response(response: Response<ByteStream>) -> FDv2SourceEvent {
-    let fallback = read_fallback_directive(response.headers());
+    let fallback =
+        read_fallback_directive(|name| response.headers().get(name).and_then(|v| v.to_str().ok()));
     let status = response.status();
 
     if status == StatusCode::NOT_MODIFIED {

--- a/launchdarkly-server-sdk/src/fdv2/protocol.rs
+++ b/launchdarkly-server-sdk/src/fdv2/protocol.rs
@@ -41,6 +41,19 @@ impl FDv2ProtocolHandler {
         self.changes.clear();
     }
 
+    /// Reports whether the FDv2 protocol handler recognizes this event type.
+    pub(super) fn is_known_event(event_type: &str) -> bool {
+        matches!(
+            event_type,
+            "server-intent"
+                | "put-object"
+                | "delete-object"
+                | "payload-transferred"
+                | "error"
+                | "goodbye"
+        )
+    }
+
     pub(super) fn handle_event(
         &mut self,
         event_type: &str,

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use futures::future::BoxFuture;
-use http::HeaderMap;
 
 use crate::stores::change_set::ChangeSet;
 
@@ -31,14 +30,14 @@ pub(crate) struct FDv1FallbackDirective {
     pub(crate) ttl: Duration,
 }
 
-pub(super) fn read_fallback_directive(headers: &HeaderMap) -> Option<FDv1FallbackDirective> {
-    let flag = headers.get(FALLBACK_HEADER)?;
-    if !flag.to_str().is_ok_and(|s| s.eq_ignore_ascii_case("true")) {
+pub(super) fn read_fallback_directive<'a>(
+    lookup: impl Fn(&str) -> Option<&'a str>,
+) -> Option<FDv1FallbackDirective> {
+    let flag = lookup(FALLBACK_HEADER)?;
+    if !flag.eq_ignore_ascii_case("true") {
         return None;
     }
-    let ttl = headers
-        .get(FALLBACK_TTL_HEADER)
-        .and_then(|v| v.to_str().ok())
+    let ttl = lookup(FALLBACK_TTL_HEADER)
         .and_then(|s| s.parse::<u64>().ok())
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_FALLBACK_TTL);
@@ -73,50 +72,47 @@ pub(crate) trait Synchronizer: Send {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
-        let mut h = HeaderMap::new();
-        for (k, v) in pairs {
-            h.insert(
-                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
-                http::HeaderValue::from_str(v).unwrap(),
-            );
-        }
-        h
+    fn headers<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<&'a str> + 'a {
+        let map: HashMap<&'a str, &'a str> = pairs.iter().copied().collect();
+        move |k| map.get(k).copied()
     }
 
     #[test]
     fn fallback_absent_header_returns_none() {
-        assert!(read_fallback_directive(&HeaderMap::new()).is_none());
+        assert!(read_fallback_directive(headers(&[])).is_none());
     }
 
     #[test]
     fn fallback_header_value_other_than_true_returns_none() {
-        let h = headers(&[("X-LD-FD-Fallback", "false")]);
-        assert!(read_fallback_directive(&h).is_none());
+        assert!(read_fallback_directive(headers(&[("X-LD-FD-Fallback", "false")])).is_none());
     }
 
     #[test]
     fn fallback_header_uppercase_true_uses_default_ttl() {
-        let h = headers(&[("X-LD-FD-Fallback", "TRUE")]);
-        let d = read_fallback_directive(&h).expect("directive");
+        let d =
+            read_fallback_directive(headers(&[("X-LD-FD-Fallback", "TRUE")])).expect("directive");
         assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
     }
 
     #[test]
     fn fallback_ttl_header_is_parsed() {
-        let h = headers(&[("X-LD-FD-Fallback", "true"), ("X-LD-FD-Fallback-TTL", "60")]);
-        let d = read_fallback_directive(&h).expect("directive");
+        let d = read_fallback_directive(headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "60"),
+        ]))
+        .expect("directive");
         assert_eq!(d.ttl, Duration::from_secs(60));
     }
 
     #[test]
     fn fallback_ttl_header_malformed_uses_default() {
-        let h = headers(&[
+        let d = read_fallback_directive(headers(&[
             ("X-LD-FD-Fallback", "true"),
             ("X-LD-FD-Fallback-TTL", "not-a-number"),
-        ]);
-        let d = read_fallback_directive(&h).expect("directive");
+        ]))
+        .expect("directive");
         assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -25,7 +25,7 @@ pub(crate) struct ErrorInfo {
     pub(crate) message: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct FDv1FallbackDirective {
     pub(crate) ttl: Duration,
 }

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -12,9 +12,10 @@ use tokio::sync::watch;
 
 use super::model::Selector;
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
+use super::request_headers::RequestHeaders;
 use super::source::{
     read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
-    FDv2SourceResult, RequestHeaders, Synchronizer,
+    FDv2SourceResult, Synchronizer,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -114,6 +114,9 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
                 }
             },
             ProtocolResult::Goodbye(g) => {
+                if let Some(reason) = &g.reason {
+                    info!("FDv2 streaming source received goodbye: {reason}");
+                }
                 // An explicit directive on the goodbye takes precedence over
                 // the most recent response header.
                 let fallback = g
@@ -124,7 +127,7 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
                     .or_else(|| self.latest_fdv1_fallback.clone());
                 self.drop_connection();
                 Some(FDv2SourceEvent {
-                    result: FDv2SourceResult::Goodbye { reason: g.reason },
+                    result: FDv2SourceResult::Goodbye,
                     fdv1_fallback: fallback,
                 })
             }
@@ -450,10 +453,7 @@ mod tests {
         )
         .expect("goodbye produced");
 
-        let FDv2SourceResult::Goodbye { reason } = out.result else {
-            panic!("expected Goodbye");
-        };
-        assert_eq!(reason.as_deref(), Some("rotating"));
+        assert!(matches!(out.result, FDv2SourceResult::Goodbye));
         assert_eq!(
             out.fdv1_fallback.map(|d| d.ttl),
             Some(Duration::from_secs(90))

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -14,7 +14,7 @@ use super::model::Selector;
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::source::{
     read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
-    FDv2SourceResult, Synchronizer,
+    FDv2SourceResult, RequestHeaders, Synchronizer,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
@@ -42,7 +42,7 @@ type EventStream = Pin<Box<dyn Stream<Item = eventsource::Result<SSE>> + Send>>;
 pub(crate) struct StreamingSynchronizer<T: HttpTransport + Clone + Send + Sync + 'static> {
     transport: T,
     base_url: String,
-    sdk_key: String,
+    headers: RequestHeaders,
     initial_reconnect_delay: Duration,
 
     url_sender: watch::Sender<Uri>,
@@ -56,14 +56,14 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
     pub(crate) fn new(
         transport: T,
         base_url: String,
-        sdk_key: String,
+        headers: RequestHeaders,
         initial_reconnect_delay: Duration,
     ) -> Self {
         let (url_sender, _) = watch::channel(Uri::default());
         Self {
             transport,
             base_url,
-            sdk_key,
+            headers,
             initial_reconnect_delay,
             url_sender,
             stream: None,
@@ -196,7 +196,7 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
 
     fn start(&mut self) -> Result<(), eventsource::Error> {
         let initial_uri = self.url_sender.borrow().clone();
-        let client = ClientBuilder::for_url(&initial_uri.to_string())?
+        let mut client_builder = ClientBuilder::for_url(&initial_uri.to_string())?
             .dynamic_url(self.url_sender.subscribe())
             .reconnect(
                 ReconnectOptionsBuilder::new(true)
@@ -204,10 +204,11 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
                     .delay(self.initial_reconnect_delay)
                     .delay_max(RECONNECT_DELAY_MAX)
                     .build(),
-            )
-            .header("Authorization", &self.sdk_key)?
-            .header("User-Agent", &crate::USER_AGENT)?
-            .build_with_transport(self.transport.clone());
+            );
+        for (name, value) in self.headers.iter() {
+            client_builder = client_builder.header(name, value)?;
+        }
+        let client = client_builder.build_with_transport(self.transport.clone());
 
         self.stream = Some(Box::pin(client.stream()));
         Ok(())
@@ -300,11 +301,15 @@ mod tests {
         }
     }
 
+    fn test_headers() -> RequestHeaders {
+        RequestHeaders::new("sdk-key", None, "test-instance")
+    }
+
     fn new_synchronizer() -> StreamingSynchronizer<NoopTransport> {
         StreamingSynchronizer::new(
             NoopTransport,
             "http://example.com".into(),
-            "sdk-key".into(),
+            test_headers(),
             Duration::ZERO,
         )
     }
@@ -573,7 +578,7 @@ mod tests {
         let mut sync = StreamingSynchronizer::new(
             transport,
             server.url(),
-            "sdk-key".into(),
+            test_headers(),
             Duration::from_millis(10),
         );
 
@@ -605,7 +610,7 @@ mod tests {
         let mut sync = StreamingSynchronizer::new(
             transport,
             server.url(),
-            "sdk-key".into(),
+            test_headers(),
             Duration::from_millis(10),
         );
 

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -43,7 +43,6 @@ pub(crate) struct StreamingSynchronizer<T: HttpTransport + Clone + Send + Sync +
     transport: T,
     base_url: String,
     sdk_key: String,
-    filter_key: Option<String>,
     initial_reconnect_delay: Duration,
 
     url_sender: watch::Sender<Uri>,
@@ -58,7 +57,6 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
         transport: T,
         base_url: String,
         sdk_key: String,
-        filter_key: Option<String>,
         initial_reconnect_delay: Duration,
     ) -> Self {
         let (url_sender, _) = watch::channel(Uri::default());
@@ -66,7 +64,6 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
             transport,
             base_url,
             sdk_key,
-            filter_key,
             initial_reconnect_delay,
             url_sender,
             stream: None,
@@ -76,13 +73,7 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
     }
 
     fn build_stream_uri(&self, selector: &Selector) -> Result<Uri, http::uri::InvalidUri> {
-        build_fdv2_url(
-            &self.base_url,
-            STREAM_ENDPOINT,
-            selector,
-            self.filter_key.as_deref(),
-        )
-        .parse::<Uri>()
+        build_fdv2_url(&self.base_url, STREAM_ENDPOINT, selector).parse::<Uri>()
     }
 
     fn drop_connection(&mut self) {
@@ -314,7 +305,6 @@ mod tests {
             NoopTransport,
             "http://example.com".into(),
             "sdk-key".into(),
-            None,
             Duration::ZERO,
         )
     }
@@ -584,7 +574,6 @@ mod tests {
             transport,
             server.url(),
             "sdk-key".into(),
-            None,
             Duration::from_millis(10),
         );
 
@@ -617,7 +606,6 @@ mod tests {
             transport,
             server.url(),
             "sdk-key".into(),
-            None,
             Duration::from_millis(10),
         );
 

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -1,0 +1,627 @@
+use std::pin::Pin;
+use std::time::Duration;
+
+use eventsource_client::{
+    self as eventsource, Client, ClientBuilder, ReconnectOptionsBuilder, SSE,
+};
+use futures::future::BoxFuture;
+use futures::{Stream, StreamExt};
+use http::Uri;
+use launchdarkly_sdk_transport::HttpTransport;
+use tokio::sync::watch;
+
+use super::model::Selector;
+use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
+use super::source::{
+    read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
+    FDv2SourceResult, Synchronizer,
+};
+use super::url::build_fdv2_url;
+use crate::reqwest::is_http_error_recoverable;
+use crate::stores::change_set::ChangeSet;
+
+const STREAM_ENDPOINT: &str = "sdk/stream";
+const RECONNECT_DELAY_MAX: Duration = Duration::from_secs(30);
+
+fn interrupted(
+    kind: ErrorKind,
+    message: impl Into<String>,
+    fallback: Option<FDv1FallbackDirective>,
+) -> FDv2SourceEvent {
+    FDv2SourceEvent {
+        result: FDv2SourceResult::Interrupted(ErrorInfo {
+            kind,
+            message: message.into(),
+        }),
+        fdv1_fallback: fallback,
+    }
+}
+
+type EventStream = Pin<Box<dyn Stream<Item = eventsource::Result<SSE>> + Send>>;
+
+pub(crate) struct StreamingSynchronizer<T: HttpTransport + Clone + Send + Sync + 'static> {
+    transport: T,
+    base_url: String,
+    sdk_key: String,
+    filter_key: Option<String>,
+    initial_reconnect_delay: Duration,
+
+    url_sender: watch::Sender<Uri>,
+    stream: Option<EventStream>,
+
+    handler: FDv2ProtocolHandler,
+    latest_fdv1_fallback: Option<FDv1FallbackDirective>,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        sdk_key: String,
+        filter_key: Option<String>,
+        initial_reconnect_delay: Duration,
+    ) -> Self {
+        let (url_sender, _) = watch::channel(Uri::default());
+        Self {
+            transport,
+            base_url,
+            sdk_key,
+            filter_key,
+            initial_reconnect_delay,
+            url_sender,
+            stream: None,
+            handler: FDv2ProtocolHandler::new(),
+            latest_fdv1_fallback: None,
+        }
+    }
+
+    fn build_stream_uri(&self, selector: &Selector) -> Result<Uri, http::uri::InvalidUri> {
+        build_fdv2_url(
+            &self.base_url,
+            STREAM_ENDPOINT,
+            selector,
+            self.filter_key.as_deref(),
+        )
+        .parse::<Uri>()
+    }
+
+    fn drop_connection(&mut self) {
+        self.stream = None;
+        self.handler.reset();
+    }
+
+    fn handle_sse_event(&mut self, event: eventsource::Event) -> Option<FDv2SourceEvent> {
+        let data: serde_json::Value = match serde_json::from_str(&event.data) {
+            Ok(v) => v,
+            Err(e) => {
+                let msg = format!("could not parse FDv2 streaming event data: {e}");
+                let fallback = self.latest_fdv1_fallback.clone();
+                self.drop_connection();
+                return Some(interrupted(ErrorKind::InvalidData, msg, fallback));
+            }
+        };
+
+        match self.handler.handle_event(&event.event_type, data) {
+            ProtocolResult::None => None,
+            ProtocolResult::ChangeSet(wire_cs) => match ChangeSet::try_from(wire_cs) {
+                Ok(cs) => Some(FDv2SourceEvent {
+                    result: FDv2SourceResult::ChangeSet(cs),
+                    fdv1_fallback: self.latest_fdv1_fallback.clone(),
+                }),
+                Err(e) => {
+                    let msg = format!("FDv2 streaming changeset could not be translated: {e}");
+                    let fallback = self.latest_fdv1_fallback.clone();
+                    self.drop_connection();
+                    Some(interrupted(ErrorKind::InvalidData, msg, fallback))
+                }
+            },
+            ProtocolResult::Goodbye(g) => {
+                // An explicit directive on the goodbye takes precedence over
+                // the most recent response header.
+                let fallback = g
+                    .protocol_fallback_ttl
+                    .map(|s| FDv1FallbackDirective {
+                        ttl: Duration::from_secs(s),
+                    })
+                    .or_else(|| self.latest_fdv1_fallback.clone());
+                self.drop_connection();
+                Some(FDv2SourceEvent {
+                    result: FDv2SourceResult::Goodbye { reason: g.reason },
+                    fdv1_fallback: fallback,
+                })
+            }
+            ProtocolResult::Error(ProtocolError::Server(err)) => {
+                let msg = format!(
+                    "An issue was encountered receiving updates for payload '{}' with reason: '{}'. Automatic retry will occur.",
+                    err.id.as_deref().unwrap_or(""),
+                    err.reason,
+                );
+                Some(interrupted(
+                    ErrorKind::ErrorResponse { status_code: 0 },
+                    msg,
+                    self.latest_fdv1_fallback.clone(),
+                ))
+            }
+            ProtocolResult::Error(ProtocolError::Protocol(msg))
+            | ProtocolResult::Error(ProtocolError::JsonParse(msg)) => {
+                let fallback = self.latest_fdv1_fallback.clone();
+                self.drop_connection();
+                Some(interrupted(ErrorKind::InvalidData, msg, fallback))
+            }
+        }
+    }
+
+    fn handle_unexpected_response(&mut self, response: &eventsource::Response) -> FDv2SourceEvent {
+        let fallback =
+            read_fallback_directive(|name| response.get_header_value(name).ok().flatten())
+                .or_else(|| self.latest_fdv1_fallback.clone());
+        let status = response.status();
+        let info = ErrorInfo {
+            kind: ErrorKind::ErrorResponse {
+                status_code: status,
+            },
+            message: format!("FDv2 streaming request received HTTP status {status}"),
+        };
+        if is_http_error_recoverable(status) {
+            FDv2SourceEvent {
+                result: FDv2SourceResult::Interrupted(info),
+                fdv1_fallback: fallback,
+            }
+        } else {
+            self.drop_connection();
+            FDv2SourceEvent {
+                result: FDv2SourceResult::TerminalError(info),
+                fdv1_fallback: fallback,
+            }
+        }
+    }
+
+    fn handle_sse_error(&mut self, error: eventsource::Error) -> Option<FDv2SourceEvent> {
+        match error {
+            eventsource::Error::Eof => None,
+            eventsource::Error::UnexpectedResponse(response, _) => {
+                Some(self.handle_unexpected_response(&response))
+            }
+            eventsource::Error::MaxRedirectLimitReached(_)
+            | eventsource::Error::InvalidParameter(_)
+            | eventsource::Error::MalformedLocationHeader(_) => {
+                let fallback = self.latest_fdv1_fallback.clone();
+                self.drop_connection();
+                Some(FDv2SourceEvent {
+                    result: FDv2SourceResult::TerminalError(ErrorInfo {
+                        kind: ErrorKind::Unknown,
+                        message: format!("FDv2 streaming connection failed: {error}"),
+                    }),
+                    fdv1_fallback: fallback,
+                })
+            }
+            other => Some(interrupted(
+                ErrorKind::NetworkError,
+                format!("{other}"),
+                self.latest_fdv1_fallback.clone(),
+            )),
+        }
+    }
+
+    fn start(&mut self) -> Result<(), eventsource::Error> {
+        let initial_uri = self.url_sender.borrow().clone();
+        let client = ClientBuilder::for_url(&initial_uri.to_string())?
+            .dynamic_url(self.url_sender.subscribe())
+            .reconnect(
+                ReconnectOptionsBuilder::new(true)
+                    .retry_initial(true)
+                    .delay(self.initial_reconnect_delay)
+                    .delay_max(RECONNECT_DELAY_MAX)
+                    .build(),
+            )
+            .header("Authorization", &self.sdk_key)?
+            .header("User-Agent", &crate::USER_AGENT)?
+            .build_with_transport(self.transport.clone());
+
+        self.stream = Some(Box::pin(client.stream()));
+        Ok(())
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> Synchronizer for StreamingSynchronizer<T> {
+    fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent> {
+        Box::pin(async move {
+            let uri = match self.build_stream_uri(&selector) {
+                Ok(u) => u,
+                Err(e) => {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::TerminalError(ErrorInfo {
+                            kind: ErrorKind::Unknown,
+                            message: format!("could not build FDv2 streaming URL: {e}"),
+                        }),
+                        fdv1_fallback: None,
+                    };
+                }
+            };
+
+            self.url_sender.send_replace(uri);
+
+            if self.stream.is_none() {
+                if let Err(e) = self.start() {
+                    return FDv2SourceEvent {
+                        result: FDv2SourceResult::TerminalError(ErrorInfo {
+                            kind: ErrorKind::Unknown,
+                            message: format!("could not start FDv2 streaming client: {e}"),
+                        }),
+                        fdv1_fallback: None,
+                    };
+                }
+            }
+
+            loop {
+                let item = self.stream.as_mut().unwrap().next().await;
+                match item {
+                    Some(Ok(SSE::Connected(details))) => {
+                        self.latest_fdv1_fallback = read_fallback_directive(|name| {
+                            details.response().get_header_value(name).ok().flatten()
+                        });
+                    }
+                    Some(Ok(SSE::Comment(_))) => continue,
+                    Some(Ok(SSE::Event(ev))) => {
+                        if let Some(out) = self.handle_sse_event(ev) {
+                            return out;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        if let Some(out) = self.handle_sse_error(e) {
+                            return out;
+                        }
+                    }
+                    None => {
+                        let fallback = self.latest_fdv1_fallback.clone();
+                        self.drop_connection();
+                        return FDv2SourceEvent {
+                            result: FDv2SourceResult::TerminalError(ErrorInfo {
+                                kind: ErrorKind::NetworkError,
+                                message: "FDv2 streaming connection exhausted".into(),
+                            }),
+                            fdv1_fallback: fallback,
+                        };
+                    }
+                }
+            }
+        })
+    }
+
+    fn name(&self) -> &str {
+        "FDv2 streaming synchronizer"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::{HeaderMap, Request, StatusCode};
+    use launchdarkly_sdk_transport::{ResponseFuture, TransportError};
+    use serde_json::json;
+
+    #[derive(Clone)]
+    struct NoopTransport;
+    impl HttpTransport for NoopTransport {
+        fn request(&self, _: Request<Option<Bytes>>) -> ResponseFuture {
+            Box::pin(async { Err(TransportError::new(std::io::Error::other("unused"))) })
+        }
+    }
+
+    fn new_synchronizer() -> StreamingSynchronizer<NoopTransport> {
+        StreamingSynchronizer::new(
+            NoopTransport,
+            "http://example.com".into(),
+            "sdk-key".into(),
+            None,
+            Duration::ZERO,
+        )
+    }
+
+    fn event(event_type: &str, data: serde_json::Value) -> eventsource::Event {
+        eventsource::Event {
+            event_type: event_type.into(),
+            data: data.to_string(),
+            id: None,
+            retry: None,
+        }
+    }
+
+    fn eventsource_response(status: u16, headers: &[(&str, &str)]) -> eventsource::Response {
+        let mut map = HeaderMap::new();
+        for (k, v) in headers {
+            map.insert(
+                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                http::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        eventsource::Response::new(StatusCode::from_u16(status).unwrap(), map)
+    }
+
+    #[test]
+    fn build_stream_uri_uses_stream_endpoint_and_selector() {
+        let sync = new_synchronizer();
+        let uri = sync.build_stream_uri(&Some("state-1".into())).unwrap();
+        assert_eq!(
+            uri.to_string(),
+            "http://example.com/sdk/stream?basis=state-1"
+        );
+    }
+
+    fn feed(
+        sync: &mut StreamingSynchronizer<NoopTransport>,
+        event_type: &str,
+        data: serde_json::Value,
+    ) -> Option<FDv2SourceEvent> {
+        sync.handle_sse_event(event(event_type, data))
+    }
+
+    fn intent(code: &str) -> serde_json::Value {
+        json!({"payloads": [{
+            "id": "p", "target": 1, "intentCode": code, "reason": "payload-missing",
+        }]})
+    }
+
+    #[test]
+    fn full_payload_cycle_emits_changeset_with_latest_fallback() {
+        let mut sync = new_synchronizer();
+        sync.latest_fdv1_fallback = Some(FDv1FallbackDirective {
+            ttl: Duration::from_secs(30),
+        });
+        let flag = crate::test_common::basic_flag("my-flag");
+        let flag_json = serde_json::to_value(&flag).unwrap();
+
+        assert!(feed(&mut sync, "server-intent", intent("xfer-full")).is_none());
+        assert!(feed(
+            &mut sync,
+            "put-object",
+            json!({"version": 1, "kind": "flag", "key": "my-flag", "object": flag_json}),
+        )
+        .is_none());
+        let out = feed(&mut sync, "payload-transferred", json!({"state": "s-1"}))
+            .expect("changeset produced");
+
+        let FDv2SourceResult::ChangeSet(cs) = out.result else {
+            panic!("expected ChangeSet, got {:?}", out.result);
+        };
+        assert_eq!(cs.changes.len(), 1);
+        assert_eq!(cs.selector.as_deref(), Some("s-1"));
+        assert_eq!(
+            out.fdv1_fallback.map(|d| d.ttl),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn malformed_event_json_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        let bad = eventsource::Event {
+            event_type: "put-object".into(),
+            data: "not json".into(),
+            id: None,
+            retry: None,
+        };
+        let out = sync.handle_sse_event(bad).expect("interrupted");
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn goodbye_ttl_takes_precedence_over_latest_fallback() {
+        let mut sync = new_synchronizer();
+        sync.latest_fdv1_fallback = Some(FDv1FallbackDirective {
+            ttl: Duration::from_secs(30),
+        });
+        let out = feed(
+            &mut sync,
+            "goodbye",
+            json!({"reason": "rotating", "protocolFallbackTTL": 90}),
+        )
+        .expect("goodbye produced");
+
+        let FDv2SourceResult::Goodbye { reason } = out.result else {
+            panic!("expected Goodbye");
+        };
+        assert_eq!(reason.as_deref(), Some("rotating"));
+        assert_eq!(
+            out.fdv1_fallback.map(|d| d.ttl),
+            Some(Duration::from_secs(90))
+        );
+    }
+
+    #[test]
+    fn goodbye_without_ttl_falls_back_to_latest() {
+        let mut sync = new_synchronizer();
+        sync.latest_fdv1_fallback = Some(FDv1FallbackDirective {
+            ttl: Duration::from_secs(30),
+        });
+        let out = feed(&mut sync, "goodbye", json!({"reason": "bye"})).expect("goodbye");
+        assert_eq!(
+            out.fdv1_fallback.map(|d| d.ttl),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn server_error_event_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        feed(&mut sync, "server-intent", intent("xfer-full"));
+        let out =
+            feed(&mut sync, "error", json!({"id": "p", "reason": "bad"})).expect("interrupted");
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert!(err.message.contains("bad"));
+    }
+
+    #[test]
+    fn unknown_intent_code_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        let out = feed(&mut sync, "server-intent", intent("brand-new")).expect("interrupted");
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn translation_failure_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        feed(&mut sync, "server-intent", intent("xfer-full"));
+        feed(
+            &mut sync,
+            "put-object",
+            json!({"version": 1, "kind": "flag", "key": "bad", "object": {"garbage": true}}),
+        );
+        let out =
+            feed(&mut sync, "payload-transferred", json!({"state": "s-1"})).expect("interrupted");
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::InvalidData);
+        assert!(err.message.contains("translated"));
+    }
+
+    #[test]
+    fn eof_returns_none() {
+        let mut sync = new_synchronizer();
+        assert!(sync.handle_sse_error(eventsource::Error::Eof).is_none());
+    }
+
+    #[test]
+    fn recoverable_status_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        let out = sync.handle_unexpected_response(&eventsource_response(500, &[]));
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::ErrorResponse { status_code: 500 });
+    }
+
+    #[test]
+    fn unrecoverable_status_returns_terminal_error_with_fallback_header() {
+        let mut sync = new_synchronizer();
+        let response = eventsource_response(401, &[("X-LD-FD-Fallback", "true")]);
+        let out = sync.handle_unexpected_response(&response);
+        let FDv2SourceResult::TerminalError(err) = out.result else {
+            panic!("expected TerminalError");
+        };
+        assert_eq!(err.kind, ErrorKind::ErrorResponse { status_code: 401 });
+        assert!(out.fdv1_fallback.is_some());
+    }
+
+    #[test]
+    fn unrecoverable_status_without_header_uses_latest_fallback() {
+        let mut sync = new_synchronizer();
+        sync.latest_fdv1_fallback = Some(FDv1FallbackDirective {
+            ttl: Duration::from_secs(42),
+        });
+        let out = sync.handle_unexpected_response(&eventsource_response(401, &[]));
+        assert_eq!(
+            out.fdv1_fallback.map(|d| d.ttl),
+            Some(Duration::from_secs(42))
+        );
+    }
+
+    #[test]
+    fn max_redirect_limit_returns_terminal_error() {
+        let mut sync = new_synchronizer();
+        let out = sync
+            .handle_sse_error(eventsource::Error::MaxRedirectLimitReached(3))
+            .expect("terminal");
+        let FDv2SourceResult::TerminalError(err) = out.result else {
+            panic!("expected TerminalError");
+        };
+        assert_eq!(err.kind, ErrorKind::Unknown);
+    }
+
+    #[test]
+    fn invalid_line_returns_interrupted() {
+        let mut sync = new_synchronizer();
+        let out = sync
+            .handle_sse_error(eventsource::Error::InvalidLine("bad".into()))
+            .expect("interrupted");
+        let FDv2SourceResult::Interrupted(err) = out.result else {
+            panic!("expected Interrupted");
+        };
+        assert_eq!(err.kind, ErrorKind::NetworkError);
+    }
+
+    fn sse_full_payload(flag_key: &str) -> String {
+        let flag = crate::test_common::basic_flag(flag_key);
+        let flag_json = serde_json::to_string(&flag).unwrap();
+        format!(
+            "event: server-intent\n\
+             data: {{\"payloads\":[{{\"id\":\"p\",\"target\":1,\"intentCode\":\"xfer-full\",\"reason\":\"payload-missing\"}}]}}\n\
+             \n\
+             event: put-object\n\
+             data: {{\"version\":1,\"kind\":\"flag\",\"key\":\"{flag_key}\",\"object\":{flag_json}}}\n\
+             \n\
+             event: payload-transferred\n\
+             data: {{\"state\":\"s-1\"}}\n\
+             \n"
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn end_to_end_full_payload_emits_changeset() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/sdk/stream")
+            .match_header("Authorization", "sdk-key")
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(sse_full_payload("f"))
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let transport = launchdarkly_sdk_transport::HyperTransport::new().expect("hyper transport");
+        let mut sync = StreamingSynchronizer::new(
+            transport,
+            server.url(),
+            "sdk-key".into(),
+            None,
+            Duration::from_millis(10),
+        );
+
+        let out = sync.next(None).await;
+        let FDv2SourceResult::ChangeSet(cs) = out.result else {
+            panic!("expected ChangeSet, got {:?}", out.result);
+        };
+        assert_eq!(cs.selector.as_deref(), Some("s-1"));
+        assert_eq!(cs.changes.len(), 1);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_request_includes_selector_in_query() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"/sdk/stream\?basis=state-1".into()),
+            )
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(sse_full_payload("f"))
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let transport = launchdarkly_sdk_transport::HyperTransport::new().expect("hyper transport");
+        let mut sync = StreamingSynchronizer::new(
+            transport,
+            server.url(),
+            "sdk-key".into(),
+            None,
+            Duration::from_millis(10),
+        );
+
+        let _ = sync.next(Some("state-1".into())).await;
+        mock.assert_async().await;
+    }
+}

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -83,6 +83,12 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
     }
 
     fn handle_sse_event(&mut self, event: eventsource::Event) -> Option<FDv2SourceEvent> {
+        // Unrecognized events are ignored without parsing their data, leaving
+        // room for future protocol additions.
+        if !FDv2ProtocolHandler::is_known_event(&event.event_type) {
+            return None;
+        }
+
         let data: serde_json::Value = match serde_json::from_str(&event.data) {
             Ok(v) => v,
             Err(e) => {
@@ -403,6 +409,32 @@ mod tests {
             panic!("expected Interrupted");
         };
         assert_eq!(err.kind, ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn unknown_event_is_ignored_without_parsing_body() {
+        let mut sync = new_synchronizer();
+
+        // An unrecognized event with a non-JSON body must be ignored, not parsed.
+        let unknown = eventsource::Event {
+            event_type: "whatever".into(),
+            data: "not json".into(),
+            id: None,
+            retry: None,
+        };
+        assert!(sync.handle_sse_event(unknown).is_none());
+
+        // The stream keeps working: a following valid cycle still produces a changeset.
+        let flag = crate::test_common::basic_flag("my-flag");
+        let flag_json = serde_json::to_value(&flag).unwrap();
+        assert!(feed(&mut sync, "server-intent", intent("xfer-full")).is_none());
+        assert!(feed(
+            &mut sync,
+            "put-object",
+            json!({"version": 1, "kind": "flag", "key": "my-flag", "object": flag_json}),
+        )
+        .is_none());
+        assert!(feed(&mut sync, "payload-transferred", json!({"state": "s-1"})).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the FDv2 streaming synchronizer, built on `eventsource-client`. It maintains a single SSE connection and uses the client's dynamic-URL support to keep the request basis in sync with the selector across reconnects.

The `eventsource-client` surfaces a non-success HTTP response to the synchronizer rather than filtering it internally, so the synchronizer classifies the status itself: a recoverable status becomes an interruption and an unrecoverable one a terminal error.
