### PR TITLE
feat: Honor the FDv1 fallback directive in the orchestrator

### DIFF
--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -645,6 +645,7 @@ mod tests {
     /// Reports an FDv1 fallback directive on its first build, then delivers data.
     struct FallbackThenDataFactory {
         ttl: Duration,
+        reengage_kind: ChangeSetKind,
         builds: AtomicUsize,
     }
 
@@ -659,10 +660,10 @@ mod tests {
                     fallback_directive: Some(FDv1FallbackDirective { ttl: self.ttl }),
                 })
             } else {
-                // After the FDv2 retry: deliver a delta.
+                // After the FDv2 retry: deliver the re-engagement payload.
                 Box::new(MockSynchronizer {
                     results: VecDeque::from(vec![changeset(
-                        ChangeSetKind::Partial,
+                        self.reengage_kind,
                         "fdv2-back",
                         Some("s".into()),
                     )]),
@@ -1536,6 +1537,7 @@ mod tests {
         let source_manager = SourceManager::new(vec![
             Arc::new(FallbackThenDataFactory {
                 ttl: Duration::from_secs(60),
+                reengage_kind: ChangeSetKind::Partial,
                 builds: AtomicUsize::new(0),
             }) as Arc<dyn SynchronizerFactory>,
             fdv1_factory(
@@ -1579,6 +1581,7 @@ mod tests {
         let source_manager = SourceManager::new(vec![
             Arc::new(FallbackThenDataFactory {
                 ttl: Duration::from_secs(60),
+                reengage_kind: ChangeSetKind::Full,
                 builds: AtomicUsize::new(0),
             }) as Arc<dyn SynchronizerFactory>,
             fdv1_factory(vec![terminal()], no_selectors(), false),

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -273,7 +273,31 @@ async fn run(
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
     let mut current = source_manager.next_synchronizer();
-    while let Some(mut active) = current {
+    loop {
+        let mut active = match current {
+            Some(active) => active,
+            None => {
+                // No synchronizer is available. While an FDv1 fallback directive's
+                // retry is pending, wait it out and return to FDv2 rather than exiting
+                // -- a blocked or terminal fallback must not strand the data system.
+                // With no retry pending, every source hit an unrecoverable error, so stop.
+                if fdv2_retry_at.is_none() {
+                    break;
+                }
+                let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
+                let mut fdv2_retry = Box::pin(deadline(fdv2_retry_at)).fuse();
+                futures::select! {
+                    _ = shutdown => return,
+                    _ = fdv2_retry => {
+                        source_manager.switch_back_to_fdv2();
+                        fdv2_retry_at = None;
+                    }
+                }
+                current = source_manager.next_synchronizer();
+                continue;
+            }
+        };
+
         let name = active.name().to_string();
         let has_fallback = source_manager.available_count() > 1;
         let has_recovery = has_fallback && !source_manager.is_prime();
@@ -1542,6 +1566,40 @@ mod tests {
         // Fell back to FDv1, then re-engaged FDv2 once the TTL expired.
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fdv1").is_some());
+        assert!(store.read().flag("fdv2-back").is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fdv2_retry_survives_a_terminal_fdv1_fallback() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializers: Vec<Box<dyn Initializer>> = vec![];
+
+        // The FDv2 source reports a 60s directive; the FDv1 fallback then fails
+        // terminally, blocking every source before the TTL expires.
+        let source_manager = SourceManager::new(vec![
+            Arc::new(FallbackThenDataFactory {
+                ttl: Duration::from_secs(60),
+                builds: AtomicUsize::new(0),
+            }) as Arc<dyn SynchronizerFactory>,
+            fdv1_factory(vec![terminal()], no_selectors(), false),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        // Paused time advances past the TTL while no source is available.
+        let handle = tokio::spawn(run(
+            initializers,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        ));
+        handle.await.unwrap();
+
+        // The blocked fallback did not strand the run; FDv2 re-engaged after the TTL.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("fdv2-back").is_some());
     }
 

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -256,9 +256,7 @@ async fn run(
         if let Some(fallback_directive) = fdv1_fallback {
             info!("FDv2 falling back to the FDv1 protocol");
             source_manager.switch_to_fdv1_fallback();
-            if fallback_directive.ttl != Duration::ZERO {
-                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
-            }
+            fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
             break;
         }
         if got_basis {
@@ -364,9 +362,7 @@ async fn run(
                         if !source_manager.is_current_fdv1_fallback() {
                             info!("FDv2 falling back to the FDv1 protocol");
                             source_manager.switch_to_fdv1_fallback();
-                            if fallback_directive.ttl != Duration::ZERO {
-                                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
-                            }
+                            fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
                             break;
                         }
                     }
@@ -460,17 +456,18 @@ mod tests {
         }
     }
 
-    /// An initializer that reports an FDv1 fallback directive with no TTL.
-    struct FallbackInitializer;
+    /// An initializer that reports an FDv1 fallback directive with the given TTL.
+    struct FallbackInitializer {
+        ttl: Duration,
+    }
 
     impl Initializer for FallbackInitializer {
         fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent> {
-            Box::pin(async {
+            let ttl = self.ttl;
+            Box::pin(async move {
                 FDv2SourceEvent {
                     result: interrupted(),
-                    fdv1_fallback: Some(FDv1FallbackDirective {
-                        ttl: Duration::ZERO,
-                    }),
+                    fdv1_fallback: Some(FDv1FallbackDirective { ttl }),
                 }
             })
         }
@@ -480,11 +477,13 @@ mod tests {
         }
     }
 
-    struct FallbackInitializerFactory;
+    struct FallbackInitializerFactory {
+        ttl: Duration,
+    }
 
     impl InitializerFactory for FallbackInitializerFactory {
         fn create(&self) -> Box<dyn Initializer> {
-            Box::new(FallbackInitializer)
+            Box::new(FallbackInitializer { ttl: self.ttl })
         }
     }
 
@@ -1308,10 +1307,10 @@ mod tests {
         let (init_complete, calls) = recording_init_complete();
         let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
-        // The FDv2 source reports a fallback directive with a zero TTL, so FDv2
-        // is never retried; the FDv1 fallback holds the basis.
+        // The FDv2 source reports a fallback directive; the FDv1 fallback then
+        // supplies the basis and ends the run.
         let source_manager = SourceManager::new(vec![
-            fallback_directive_factory(Duration::ZERO),
+            fallback_directive_factory(Duration::from_secs(60)),
             fdv1_factory(
                 vec![changeset(
                     ChangeSetKind::Full,
@@ -1387,7 +1386,7 @@ mod tests {
     async fn fdv2_retry_survives_a_terminal_fdv1_fallback() {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
-        let initializers: Vec<Box<dyn Initializer>> = vec![];
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
         // The FDv2 source reports a 60s directive; the FDv1 fallback then fails
         // terminally, blocking every source before the TTL expires.
@@ -1402,7 +1401,7 @@ mod tests {
 
         // Paused time advances past the TTL while no source is available.
         let handle = tokio::spawn(run(
-            initializers,
+            initializer_factories,
             source_manager,
             store.clone(),
             init_complete,
@@ -1422,9 +1421,12 @@ mod tests {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
         let initializer_factories: Vec<Arc<dyn InitializerFactory>> =
-            vec![Arc::new(FallbackInitializerFactory)];
+            vec![Arc::new(FallbackInitializerFactory {
+                ttl: Duration::from_secs(60),
+            })];
 
-        // The FDv2 synchronizer is never reached; the FDv1 fallback holds the basis.
+        // The initializer's directive switches to the FDv1 fallback, which supplies
+        // the basis and ends the run.
         let source_manager = SourceManager::new(vec![
             sync_factory(vec![], no_selectors(), false),
             fdv1_factory(

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -217,40 +217,56 @@ async fn run(
 ) {
     let mut selector: Selector = None;
     let mut initialized = false;
+    let mut fdv2_retry_at: Option<Instant> = None;
 
-    // Initializer phase: try each in order until one yields a basis.
+    // Initializer phase: try each in order until one yields a basis or an
+    // FDv1 fallback directive.
     for factory in initializer_factories {
         let mut initializer = factory.create();
         let name = initializer.name().to_string();
         let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
-        futures::select! {
+        let event = futures::select! {
             _ = shutdown => return,
-            event = initializer.run().fuse() => {
-                match event.result {
-                    FDv2SourceResult::ChangeSet(change_set)
-                        if !matches!(change_set.kind, ChangeSetKind::None) =>
-                    {
-                        let got_basis = change_set.selector.is_some();
-                        if got_basis {
-                            selector = change_set.selector.clone();
-                        }
-                        store.write().apply(change_set);
-                        if !initialized {
-                            init_complete(true);
-                            initialized = true;
-                        }
-                        if got_basis {
-                            break;
-                        }
-                    }
-                    _ => debug!("{name} did not provide a basis"),
+            event = initializer.run().fuse() => event,
+        };
+
+        let FDv2SourceEvent {
+            result,
+            fdv1_fallback,
+        } = event;
+        let mut got_basis = false;
+        match result {
+            FDv2SourceResult::ChangeSet(change_set)
+                if !matches!(change_set.kind, ChangeSetKind::None) =>
+            {
+                got_basis = change_set.selector.is_some();
+                if got_basis {
+                    selector = change_set.selector.clone();
+                }
+                store.write().apply(change_set);
+                if !initialized {
+                    init_complete(true);
+                    initialized = true;
                 }
             }
+            _ => debug!("{name} did not provide a basis"),
+        }
+        // An FDv1 fallback directive ends the initializer phase and switches
+        // to the fallback.
+        if let Some(fallback_directive) = fdv1_fallback {
+            info!("FDv2 falling back to the FDv1 protocol");
+            source_manager.switch_to_fdv1_fallback();
+            if fallback_directive.ttl != Duration::ZERO {
+                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
+            }
+            break;
+        }
+        if got_basis {
+            break;
         }
     }
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
-    let mut fdv2_retry_at: Option<Instant> = None;
     let mut current = source_manager.next_synchronizer();
     while let Some(mut active) = current {
         let name = active.name().to_string();
@@ -319,13 +335,13 @@ async fn run(
                         }
                         FDv2SourceResult::Shutdown => return,
                     }
-                    // A fallback directive takes precedence over a terminal error.
-                    if let Some(directive) = fdv1_fallback {
+                    // An FDv1 fallback directive takes precedence over a terminal error.
+                    if let Some(fallback_directive) = fdv1_fallback {
                         if !source_manager.is_current_fdv1_fallback() {
                             info!("FDv2 falling back to the FDv1 protocol");
                             source_manager.switch_to_fdv1_fallback();
-                            if directive.ttl != Duration::ZERO {
-                                fdv2_retry_at = Some(Instant::now() + directive.ttl);
+                            if fallback_directive.ttl != Duration::ZERO {
+                                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
                             }
                             break;
                         }
@@ -417,6 +433,34 @@ mod tests {
 
         fn name(&self) -> &str {
             "mock-initializer"
+        }
+    }
+
+    /// An initializer that reports an FDv1 fallback directive with no TTL.
+    struct FallbackInitializer;
+
+    impl Initializer for FallbackInitializer {
+        fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent> {
+            Box::pin(async {
+                FDv2SourceEvent {
+                    result: interrupted(),
+                    fdv1_fallback: Some(FDv1FallbackDirective {
+                        ttl: Duration::ZERO,
+                    }),
+                }
+            })
+        }
+
+        fn name(&self) -> &str {
+            "fallback-initializer"
+        }
+    }
+
+    struct FallbackInitializerFactory;
+
+    impl InitializerFactory for FallbackInitializerFactory {
+        fn create(&self) -> Box<dyn Initializer> {
+            Box::new(FallbackInitializer)
         }
     }
 
@@ -1238,7 +1282,7 @@ mod tests {
     async fn fallback_directive_switches_to_fdv1() {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
-        let initializers: Vec<Box<dyn Initializer>> = vec![];
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
         // The FDv2 source reports a fallback directive with a zero TTL, so FDv2
         // is never retried; the FDv1 fallback holds the basis.
@@ -1257,7 +1301,7 @@ mod tests {
         let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
 
         run(
-            initializers,
+            initializer_factories,
             source_manager,
             store.clone(),
             init_complete,
@@ -1276,7 +1320,7 @@ mod tests {
     async fn fdv2_retry_reengages_after_ttl() {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
-        let initializers: Vec<Box<dyn Initializer>> = vec![];
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
         // The FDv2 source reports a directive with a 60s TTL; the FDv1 fallback
         // supplies a basis and then idles until FDv2 is retried.
@@ -1299,7 +1343,7 @@ mod tests {
 
         // Paused time auto-advances past the TTL, re-engaging FDv2.
         let handle = tokio::spawn(run(
-            initializers,
+            initializer_factories,
             source_manager,
             store.clone(),
             init_complete,
@@ -1313,5 +1357,43 @@ mod tests {
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fdv1").is_some());
         assert!(store.read().flag("fdv2-back").is_some());
+    }
+
+    #[tokio::test]
+    async fn initializer_fallback_directive_switches_to_fdv1() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> =
+            vec![Arc::new(FallbackInitializerFactory)];
+
+        // The FDv2 synchronizer is never reached; the FDv1 fallback holds the basis.
+        let source_manager = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                false,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        run(
+            initializer_factories,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        )
+        .await;
+
+        // The initializer's directive switched straight to the FDv1 fallback.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -10,7 +10,7 @@ use crate::data_system::DataSystem;
 use crate::stores::store::{DataStore, InMemoryDataStore, TransactionalDataStore};
 
 use super::model::{ChangeSetKind, Selector};
-use super::source::{FDv2SourceResult, Initializer, Synchronizer};
+use super::source::{FDv2SourceEvent, FDv2SourceResult, Initializer, Synchronizer};
 
 /// Produces a fresh initializer each time the orchestrator starts a run.
 pub(crate) trait InitializerFactory: Send + Sync {
@@ -20,6 +20,11 @@ pub(crate) trait InitializerFactory: Send + Sync {
 /// Produces a fresh synchronizer each time the orchestrator starts a run.
 pub(crate) trait SynchronizerFactory: Send + Sync {
     fn create(&self) -> Box<dyn Synchronizer>;
+
+    /// Whether this factory builds the FDv1 fallback synchronizer.
+    fn is_fdv1_fallback(&self) -> bool {
+        false
+    }
 }
 
 /// FDv2 orchestrator: owns the memory store and keeps it populated by running
@@ -94,7 +99,17 @@ struct SourceManager {
 
 impl SourceManager {
     fn new(factories: Vec<Arc<dyn SynchronizerFactory>>) -> Self {
-        let states = vec![SourceState::Available; factories.len()];
+        // FDv1 fallback factories start blocked; they activate only on a directive.
+        let states = factories
+            .iter()
+            .map(|f| {
+                if f.is_fdv1_fallback() {
+                    SourceState::Blocked
+                } else {
+                    SourceState::Available
+                }
+            })
+            .collect();
         Self {
             factories,
             states,
@@ -151,6 +166,36 @@ impl SourceManager {
             .filter(|s| **s == SourceState::Available)
             .count()
     }
+
+    /// Blocks the FDv2 synchronizers and activates the FDv1 fallback, if any.
+    fn switch_to_fdv1_fallback(&mut self) {
+        for (i, factory) in self.factories.iter().enumerate() {
+            self.states[i] = if factory.is_fdv1_fallback() {
+                SourceState::Available
+            } else {
+                SourceState::Blocked
+            };
+        }
+        self.synchronizer_index = None;
+    }
+
+    /// Restores the initial state: FDv2 available, FDv1 fallback blocked.
+    fn switch_back_to_fdv2(&mut self) {
+        for (i, factory) in self.factories.iter().enumerate() {
+            self.states[i] = if factory.is_fdv1_fallback() {
+                SourceState::Blocked
+            } else {
+                SourceState::Available
+            };
+        }
+        self.synchronizer_index = None;
+    }
+
+    /// Whether the active factory is the FDv1 fallback.
+    fn is_current_fdv1_fallback(&self) -> bool {
+        self.current_factory_index
+            .is_some_and(|i| self.factories[i].is_fdv1_fallback())
+    }
 }
 
 /// Sleeps until `at`, or never when `None` (an inactive timer arm).
@@ -205,6 +250,7 @@ async fn run(
     }
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
+    let mut fdv2_retry_at: Option<Instant> = None;
     let mut current = source_manager.next_synchronizer();
     while let Some(mut active) = current {
         let name = active.name().to_string();
@@ -219,6 +265,7 @@ async fn run(
             let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
             let mut fallback = Box::pin(deadline(fallback_at)).fuse();
             let mut recovery = Box::pin(deadline(recovery_at)).fuse();
+            let mut fdv2_retry = Box::pin(deadline(fdv2_retry_at)).fuse();
             let mut next = active.next(selector.clone()).fuse();
             futures::select! {
                 _ = shutdown => return,
@@ -229,42 +276,66 @@ async fn run(
                     source_manager.reset_source_index();
                     break;
                 }
-                event = next => match event.result {
-                    FDv2SourceResult::ChangeSet(change_set) => {
-                        if !matches!(change_set.kind, ChangeSetKind::None) {
-                            if change_set.selector.is_some() {
-                                selector = change_set.selector.clone();
+                // Re-engage FDv2 once the fallback directive's TTL expires.
+                _ = fdv2_retry => {
+                    source_manager.switch_back_to_fdv2();
+                    fdv2_retry_at = None;
+                    break;
+                }
+                event = next => {
+                    let FDv2SourceEvent { result, fdv1_fallback } = event;
+                    let mut terminal = false;
+                    match result {
+                        FDv2SourceResult::ChangeSet(change_set) => {
+                            if !matches!(change_set.kind, ChangeSetKind::None) {
+                                if change_set.selector.is_some() {
+                                    selector = change_set.selector.clone();
+                                }
+                                store.write().apply(change_set);
+                                if !initialized {
+                                    init_complete(true);
+                                    initialized = true;
+                                }
                             }
-                            store.write().apply(change_set);
-                            if !initialized {
-                                init_complete(true);
-                                initialized = true;
+                            // A successful response clears the countdown.
+                            fallback_at = None;
+                            interrupted_logged = false;
+                        }
+                        // Sustained interruption starts the fallback countdown.
+                        FDv2SourceResult::Interrupted(error) => {
+                            if !interrupted_logged {
+                                info!("{name} interrupted: {}", error.message);
+                                interrupted_logged = true;
+                            }
+                            if has_fallback && fallback_at.is_none() {
+                                fallback_at = Some(Instant::now() + fallback_timeout);
                             }
                         }
-                        // A successful response clears the countdown.
-                        fallback_at = None;
-                        interrupted_logged = false;
-                    }
-                    // Sustained interruption starts the fallback countdown.
-                    FDv2SourceResult::Interrupted(error) => {
-                        if !interrupted_logged {
-                            info!("{name} interrupted: {}", error.message);
-                            interrupted_logged = true;
+                        // Handled internally by the synchronizer.
+                        FDv2SourceResult::Goodbye => {}
+                        FDv2SourceResult::TerminalError(error) => {
+                            warn!("{name} terminal error: {}", error.message);
+                            terminal = true;
                         }
-                        if has_fallback && fallback_at.is_none() {
-                            fallback_at = Some(Instant::now() + fallback_timeout);
+                        FDv2SourceResult::Shutdown => return,
+                    }
+                    // A fallback directive takes precedence over a terminal error.
+                    if let Some(directive) = fdv1_fallback {
+                        if !source_manager.is_current_fdv1_fallback() {
+                            info!("FDv2 falling back to the FDv1 protocol");
+                            source_manager.switch_to_fdv1_fallback();
+                            if directive.ttl != Duration::ZERO {
+                                fdv2_retry_at = Some(Instant::now() + directive.ttl);
+                            }
+                            break;
                         }
                     }
-                    // Handled internally by the synchronizer.
-                    FDv2SourceResult::Goodbye => {}
-                    FDv2SourceResult::TerminalError(error) => {
-                        warn!("{name} terminal error: {}", error.message);
+                    if terminal {
                         // Dead source: drop it and advance.
                         source_manager.block_current();
                         break;
                     }
-                    FDv2SourceResult::Shutdown => return,
-                },
+                }
             }
         }
 
@@ -288,7 +359,7 @@ mod tests {
     use launchdarkly_server_sdk_evaluation::Store;
 
     use super::super::model::ChangeSetKind;
-    use super::super::source::{ErrorInfo, ErrorKind, FDv2SourceEvent};
+    use super::super::source::{ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent};
     use crate::stores::change_set::{ChangeSet, ItemChange};
     use crate::stores::store_types::StorageItem;
     use crate::test_common::basic_flag;
@@ -353,13 +424,22 @@ mod tests {
         results: VecDeque<FDv2SourceResult>,
         selectors_seen: Selectors,
         hang: bool,
+        fallback_directive: Option<FDv1FallbackDirective>,
     }
 
     impl Synchronizer for MockSynchronizer {
         fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent> {
             self.selectors_seen.lock().unwrap().push(selector);
             match self.results.pop_front() {
-                Some(result) => Box::pin(async move { event(result) }),
+                Some(result) => {
+                    let fdv1_fallback = self.fallback_directive.clone();
+                    Box::pin(async move {
+                        FDv2SourceEvent {
+                            result,
+                            fdv1_fallback,
+                        }
+                    })
+                }
                 // Out of scripted results: idle if hang, otherwise end the run.
                 None if self.hang => Box::pin(std::future::pending()),
                 None => Box::pin(async move { event(FDv2SourceResult::Shutdown) }),
@@ -395,6 +475,8 @@ mod tests {
         results: Mutex<Vec<FDv2SourceResult>>,
         selectors_seen: Selectors,
         hang: bool,
+        is_fdv1_fallback: bool,
+        fallback_directive: Option<FDv1FallbackDirective>,
     }
 
     impl SynchronizerFactory for MockSynchronizerFactory {
@@ -404,7 +486,12 @@ mod tests {
                 results: results.into(),
                 selectors_seen: self.selectors_seen.clone(),
                 hang: self.hang,
+                fallback_directive: self.fallback_directive.clone(),
             })
+        }
+
+        fn is_fdv1_fallback(&self) -> bool {
+            self.is_fdv1_fallback
         }
     }
 
@@ -423,6 +510,34 @@ mod tests {
             results: Mutex::new(results),
             selectors_seen,
             hang,
+            is_fdv1_fallback: false,
+            fallback_directive: None,
+        })
+    }
+
+    /// Like `sync_factory`, but flagged as the FDv1 fallback.
+    fn fdv1_factory(
+        results: Vec<FDv2SourceResult>,
+        selectors_seen: Selectors,
+        hang: bool,
+    ) -> Arc<dyn SynchronizerFactory> {
+        Arc::new(MockSynchronizerFactory {
+            results: Mutex::new(results),
+            selectors_seen,
+            hang,
+            is_fdv1_fallback: true,
+            fallback_directive: None,
+        })
+    }
+
+    /// An FDv2 synchronizer that reports an FDv1 fallback directive.
+    fn fallback_directive_factory(ttl: Duration) -> Arc<dyn SynchronizerFactory> {
+        Arc::new(MockSynchronizerFactory {
+            results: Mutex::new(vec![interrupted()]),
+            selectors_seen: no_selectors(),
+            hang: true,
+            is_fdv1_fallback: false,
+            fallback_directive: Some(FDv1FallbackDirective { ttl }),
         })
     }
 
@@ -451,7 +566,40 @@ mod tests {
                 results: results.into(),
                 selectors_seen: no_selectors(),
                 hang,
+                fallback_directive: None,
             })
+        }
+    }
+
+    /// Reports an FDv1 fallback directive on its first build, then delivers data.
+    struct FallbackThenDataFactory {
+        ttl: Duration,
+        builds: AtomicUsize,
+    }
+
+    impl SynchronizerFactory for FallbackThenDataFactory {
+        fn create(&self) -> Box<dyn Synchronizer> {
+            if self.builds.fetch_add(1, Ordering::SeqCst) == 0 {
+                // First: report the fallback directive, then idle.
+                Box::new(MockSynchronizer {
+                    results: VecDeque::from(vec![interrupted()]),
+                    selectors_seen: no_selectors(),
+                    hang: true,
+                    fallback_directive: Some(FDv1FallbackDirective { ttl: self.ttl }),
+                })
+            } else {
+                // After the FDv2 retry: deliver a delta.
+                Box::new(MockSynchronizer {
+                    results: VecDeque::from(vec![changeset(
+                        ChangeSetKind::Partial,
+                        "fdv2-back",
+                        Some("s".into()),
+                    )]),
+                    selectors_seen: no_selectors(),
+                    hang: false,
+                    fallback_directive: None,
+                })
+            }
         }
     }
 
@@ -897,6 +1045,57 @@ mod tests {
         assert_eq!(sources.available_count(), 1);
     }
 
+    #[test]
+    fn fdv1_fallback_factory_starts_blocked() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // Only the FDv2 synchronizer is available; the FDv1 fallback is dormant.
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(!sources.is_current_fdv1_fallback());
+    }
+
+    #[test]
+    fn switch_to_and_back_from_fdv1_fallback() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // The directive activates only the FDv1 fallback.
+        sources.switch_to_fdv1_fallback();
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(sources.is_current_fdv1_fallback());
+
+        // Switching back restores the FDv2 synchronizer and re-blocks FDv1.
+        sources.switch_back_to_fdv2();
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(!sources.is_current_fdv1_fallback());
+    }
+
+    #[test]
+    fn switch_back_unblocks_terminally_blocked_fdv2() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // A terminal error blocks the only FDv2 synchronizer.
+        sources.next_synchronizer();
+        sources.block_current();
+        assert_eq!(sources.available_count(), 0);
+
+        // A fallback round-trip makes the FDv2 synchronizer usable again.
+        sources.switch_to_fdv1_fallback();
+        sources.switch_back_to_fdv2();
+        assert_eq!(sources.available_count(), 1);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn fallback_fires_after_sustained_interruption() {
         // No initializers; the prime interrupts then idles.
@@ -1033,5 +1232,86 @@ mod tests {
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fallback").is_some());
         assert!(store.read().flag("prime-recovered").is_some());
+    }
+
+    #[tokio::test]
+    async fn fallback_directive_switches_to_fdv1() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializers: Vec<Box<dyn Initializer>> = vec![];
+
+        // The FDv2 source reports a fallback directive with a zero TTL, so FDv2
+        // is never retried; the FDv1 fallback holds the basis.
+        let source_manager = SourceManager::new(vec![
+            fallback_directive_factory(Duration::ZERO),
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                false,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        run(
+            initializers,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        )
+        .await;
+
+        // Switched to the FDv1 fallback and applied its basis.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fdv2_retry_reengages_after_ttl() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializers: Vec<Box<dyn Initializer>> = vec![];
+
+        // The FDv2 source reports a directive with a 60s TTL; the FDv1 fallback
+        // supplies a basis and then idles until FDv2 is retried.
+        let source_manager = SourceManager::new(vec![
+            Arc::new(FallbackThenDataFactory {
+                ttl: Duration::from_secs(60),
+                builds: AtomicUsize::new(0),
+            }) as Arc<dyn SynchronizerFactory>,
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                true,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        // Paused time auto-advances past the TTL, re-engaging FDv2.
+        let handle = tokio::spawn(run(
+            initializers,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        ));
+        handle.await.unwrap();
+
+        // Fell back to FDv1, then re-engaged FDv2 once the TTL expired.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
+        assert!(store.read().flag("fdv2-back").is_some());
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -268,7 +268,31 @@ async fn run(
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
     let mut current = source_manager.next_synchronizer();
-    while let Some(mut active) = current {
+    loop {
+        let mut active = match current {
+            Some(active) => active,
+            None => {
+                // No synchronizer is available. While an FDv1 fallback directive's
+                // retry is pending, wait it out and return to FDv2 rather than exiting
+                // -- a blocked or terminal fallback must not strand the data system.
+                // With no retry pending, every source hit an unrecoverable error, so stop.
+                if fdv2_retry_at.is_none() {
+                    break;
+                }
+                let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
+                let mut fdv2_retry = Box::pin(deadline(fdv2_retry_at)).fuse();
+                futures::select! {
+                    _ = shutdown => return,
+                    _ = fdv2_retry => {
+                        source_manager.switch_back_to_fdv2();
+                        fdv2_retry_at = None;
+                    }
+                }
+                current = source_manager.next_synchronizer();
+                continue;
+            }
+        };
+
         let name = active.name().to_string();
         let has_fallback = source_manager.available_count() > 1;
         let has_recovery = has_fallback && !source_manager.is_prime();
@@ -1356,6 +1380,40 @@ mod tests {
         // Fell back to FDv1, then re-engaged FDv2 once the TTL expired.
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fdv1").is_some());
+        assert!(store.read().flag("fdv2-back").is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fdv2_retry_survives_a_terminal_fdv1_fallback() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializers: Vec<Box<dyn Initializer>> = vec![];
+
+        // The FDv2 source reports a 60s directive; the FDv1 fallback then fails
+        // terminally, blocking every source before the TTL expires.
+        let source_manager = SourceManager::new(vec![
+            Arc::new(FallbackThenDataFactory {
+                ttl: Duration::from_secs(60),
+                builds: AtomicUsize::new(0),
+            }) as Arc<dyn SynchronizerFactory>,
+            fdv1_factory(vec![terminal()], no_selectors(), false),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        // Paused time advances past the TTL while no source is available.
+        let handle = tokio::spawn(run(
+            initializers,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        ));
+        handle.await.unwrap();
+
+        // The blocked fallback did not strand the run; FDv2 re-engaged after the TTL.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("fdv2-back").is_some());
     }
 

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -238,12 +238,12 @@ async fn run(
         } = event;
         let mut has_basis = false;
         match result {
-            FDv2SourceResult::ChangeSet(change_set)
-                if !matches!(change_set.kind, ChangeSetKind::None) =>
-            {
+            FDv2SourceResult::ChangeSet(change_set) => {
                 let is_full = matches!(change_set.kind, ChangeSetKind::Full);
                 has_basis = is_full && change_set.selector.is_some();
-                selector = change_set.selector.clone();
+                if !matches!(change_set.kind, ChangeSetKind::None) {
+                    selector = change_set.selector.clone();
+                }
                 store.write().apply(change_set);
                 if is_full {
                     got_full = true;

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -10,7 +10,7 @@ use crate::data_system::DataSystem;
 use crate::stores::store::{DataStore, InMemoryDataStore, TransactionalDataStore};
 
 use super::model::{ChangeSetKind, Selector};
-use super::source::{FDv2SourceResult, Initializer, Synchronizer};
+use super::source::{FDv2SourceEvent, FDv2SourceResult, Initializer, Synchronizer};
 
 /// Produces a fresh initializer each time the orchestrator starts a run.
 pub(crate) trait InitializerFactory: Send + Sync {
@@ -20,6 +20,11 @@ pub(crate) trait InitializerFactory: Send + Sync {
 /// Produces a fresh synchronizer each time the orchestrator starts a run.
 pub(crate) trait SynchronizerFactory: Send + Sync {
     fn create(&self) -> Box<dyn Synchronizer>;
+
+    /// Whether this factory builds the FDv1 fallback synchronizer.
+    fn is_fdv1_fallback(&self) -> bool {
+        false
+    }
 }
 
 /// FDv2 orchestrator: owns the memory store and keeps it populated by running
@@ -94,7 +99,17 @@ struct SourceManager {
 
 impl SourceManager {
     fn new(factories: Vec<Arc<dyn SynchronizerFactory>>) -> Self {
-        let states = vec![SourceState::Available; factories.len()];
+        // FDv1 fallback factories start blocked; they activate only on a directive.
+        let states = factories
+            .iter()
+            .map(|f| {
+                if f.is_fdv1_fallback() {
+                    SourceState::Blocked
+                } else {
+                    SourceState::Available
+                }
+            })
+            .collect();
         Self {
             factories,
             states,
@@ -150,6 +165,36 @@ impl SourceManager {
             .iter()
             .filter(|s| **s == SourceState::Available)
             .count()
+    }
+
+    /// Blocks the FDv2 synchronizers and activates the FDv1 fallback, if any.
+    fn switch_to_fdv1_fallback(&mut self) {
+        for (i, factory) in self.factories.iter().enumerate() {
+            self.states[i] = if factory.is_fdv1_fallback() {
+                SourceState::Available
+            } else {
+                SourceState::Blocked
+            };
+        }
+        self.synchronizer_index = None;
+    }
+
+    /// Restores the initial state: FDv2 available, FDv1 fallback blocked.
+    fn switch_back_to_fdv2(&mut self) {
+        for (i, factory) in self.factories.iter().enumerate() {
+            self.states[i] = if factory.is_fdv1_fallback() {
+                SourceState::Blocked
+            } else {
+                SourceState::Available
+            };
+        }
+        self.synchronizer_index = None;
+    }
+
+    /// Whether the active factory is the FDv1 fallback.
+    fn is_current_fdv1_fallback(&self) -> bool {
+        self.current_factory_index
+            .is_some_and(|i| self.factories[i].is_fdv1_fallback())
     }
 }
 
@@ -210,6 +255,7 @@ async fn run(
     }
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
+    let mut fdv2_retry_at: Option<Instant> = None;
     let mut current = source_manager.next_synchronizer();
     while let Some(mut active) = current {
         let name = active.name().to_string();
@@ -224,6 +270,7 @@ async fn run(
             let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
             let mut fallback = Box::pin(deadline(fallback_at)).fuse();
             let mut recovery = Box::pin(deadline(recovery_at)).fuse();
+            let mut fdv2_retry = Box::pin(deadline(fdv2_retry_at)).fuse();
             let mut next = active.next(selector.clone()).fuse();
             futures::select! {
                 _ = shutdown => return,
@@ -234,41 +281,65 @@ async fn run(
                     source_manager.reset_source_index();
                     break;
                 }
-                event = next => match event.result {
-                    FDv2SourceResult::ChangeSet(change_set) => {
-                        let is_full = matches!(change_set.kind, ChangeSetKind::Full);
-                        if !matches!(change_set.kind, ChangeSetKind::None) {
-                            selector = change_set.selector.clone();
-                            store.write().apply(change_set);
-                            if is_full && !initialized {
-                                init_complete(true);
-                                initialized = true;
+                // Re-engage FDv2 once the fallback directive's TTL expires.
+                _ = fdv2_retry => {
+                    source_manager.switch_back_to_fdv2();
+                    fdv2_retry_at = None;
+                    break;
+                }
+                event = next => {
+                    let FDv2SourceEvent { result, fdv1_fallback } = event;
+                    let mut terminal = false;
+                    match result {
+                        FDv2SourceResult::ChangeSet(change_set) => {
+                            let is_full = matches!(change_set.kind, ChangeSetKind::Full);
+                            if !matches!(change_set.kind, ChangeSetKind::None) {
+                                selector = change_set.selector.clone();
+                                store.write().apply(change_set);
+                                if is_full && !initialized {
+                                    init_complete(true);
+                                    initialized = true;
+                                }
+                            }
+                            // A successful response clears the countdown.
+                            fallback_at = None;
+                            interrupted_logged = false;
+                        }
+                        // Sustained interruption starts the fallback countdown.
+                        FDv2SourceResult::Interrupted(error) => {
+                            if !interrupted_logged {
+                                info!("{name} interrupted: {}", error.message);
+                                interrupted_logged = true;
+                            }
+                            if has_fallback && fallback_at.is_none() {
+                                fallback_at = Some(Instant::now() + fallback_timeout);
                             }
                         }
-                        // A successful response clears the countdown.
-                        fallback_at = None;
-                        interrupted_logged = false;
-                    }
-                    // Sustained interruption starts the fallback countdown.
-                    FDv2SourceResult::Interrupted(error) => {
-                        if !interrupted_logged {
-                            info!("{name} interrupted: {}", error.message);
-                            interrupted_logged = true;
+                        // Handled internally by the synchronizer.
+                        FDv2SourceResult::Goodbye => {}
+                        FDv2SourceResult::TerminalError(error) => {
+                            warn!("{name} terminal error: {}", error.message);
+                            terminal = true;
                         }
-                        if has_fallback && fallback_at.is_none() {
-                            fallback_at = Some(Instant::now() + fallback_timeout);
+                        FDv2SourceResult::Shutdown => return,
+                    }
+                    // A fallback directive takes precedence over a terminal error.
+                    if let Some(directive) = fdv1_fallback {
+                        if !source_manager.is_current_fdv1_fallback() {
+                            info!("FDv2 falling back to the FDv1 protocol");
+                            source_manager.switch_to_fdv1_fallback();
+                            if directive.ttl != Duration::ZERO {
+                                fdv2_retry_at = Some(Instant::now() + directive.ttl);
+                            }
+                            break;
                         }
                     }
-                    // Handled internally by the synchronizer.
-                    FDv2SourceResult::Goodbye => {}
-                    FDv2SourceResult::TerminalError(error) => {
-                        warn!("{name} terminal error: {}", error.message);
+                    if terminal {
                         // Dead source: drop it and advance.
                         source_manager.block_current();
                         break;
                     }
-                    FDv2SourceResult::Shutdown => return,
-                },
+                }
             }
         }
 
@@ -292,7 +363,7 @@ mod tests {
     use launchdarkly_server_sdk_evaluation::Store;
 
     use super::super::model::ChangeSetKind;
-    use super::super::source::{ErrorInfo, ErrorKind, FDv2SourceEvent};
+    use super::super::source::{ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent};
     use crate::stores::change_set::{ChangeSet, ItemChange};
     use crate::stores::store_types::StorageItem;
     use crate::test_common::basic_flag;
@@ -357,13 +428,22 @@ mod tests {
         results: VecDeque<FDv2SourceResult>,
         selectors_seen: Selectors,
         hang: bool,
+        fallback_directive: Option<FDv1FallbackDirective>,
     }
 
     impl Synchronizer for MockSynchronizer {
         fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent> {
             self.selectors_seen.lock().unwrap().push(selector);
             match self.results.pop_front() {
-                Some(result) => Box::pin(async move { event(result) }),
+                Some(result) => {
+                    let fdv1_fallback = self.fallback_directive.clone();
+                    Box::pin(async move {
+                        FDv2SourceEvent {
+                            result,
+                            fdv1_fallback,
+                        }
+                    })
+                }
                 // Out of scripted results: idle if hang, otherwise end the run.
                 None if self.hang => Box::pin(std::future::pending()),
                 None => Box::pin(async move { event(FDv2SourceResult::Shutdown) }),
@@ -399,6 +479,8 @@ mod tests {
         results: Mutex<Vec<FDv2SourceResult>>,
         selectors_seen: Selectors,
         hang: bool,
+        is_fdv1_fallback: bool,
+        fallback_directive: Option<FDv1FallbackDirective>,
     }
 
     impl SynchronizerFactory for MockSynchronizerFactory {
@@ -408,7 +490,12 @@ mod tests {
                 results: results.into(),
                 selectors_seen: self.selectors_seen.clone(),
                 hang: self.hang,
+                fallback_directive: self.fallback_directive.clone(),
             })
+        }
+
+        fn is_fdv1_fallback(&self) -> bool {
+            self.is_fdv1_fallback
         }
     }
 
@@ -427,6 +514,34 @@ mod tests {
             results: Mutex::new(results),
             selectors_seen,
             hang,
+            is_fdv1_fallback: false,
+            fallback_directive: None,
+        })
+    }
+
+    /// Like `sync_factory`, but flagged as the FDv1 fallback.
+    fn fdv1_factory(
+        results: Vec<FDv2SourceResult>,
+        selectors_seen: Selectors,
+        hang: bool,
+    ) -> Arc<dyn SynchronizerFactory> {
+        Arc::new(MockSynchronizerFactory {
+            results: Mutex::new(results),
+            selectors_seen,
+            hang,
+            is_fdv1_fallback: true,
+            fallback_directive: None,
+        })
+    }
+
+    /// An FDv2 synchronizer that reports an FDv1 fallback directive.
+    fn fallback_directive_factory(ttl: Duration) -> Arc<dyn SynchronizerFactory> {
+        Arc::new(MockSynchronizerFactory {
+            results: Mutex::new(vec![interrupted()]),
+            selectors_seen: no_selectors(),
+            hang: true,
+            is_fdv1_fallback: false,
+            fallback_directive: Some(FDv1FallbackDirective { ttl }),
         })
     }
 
@@ -455,7 +570,40 @@ mod tests {
                 results: results.into(),
                 selectors_seen: no_selectors(),
                 hang,
+                fallback_directive: None,
             })
+        }
+    }
+
+    /// Reports an FDv1 fallback directive on its first build, then delivers data.
+    struct FallbackThenDataFactory {
+        ttl: Duration,
+        builds: AtomicUsize,
+    }
+
+    impl SynchronizerFactory for FallbackThenDataFactory {
+        fn create(&self) -> Box<dyn Synchronizer> {
+            if self.builds.fetch_add(1, Ordering::SeqCst) == 0 {
+                // First: report the fallback directive, then idle.
+                Box::new(MockSynchronizer {
+                    results: VecDeque::from(vec![interrupted()]),
+                    selectors_seen: no_selectors(),
+                    hang: true,
+                    fallback_directive: Some(FDv1FallbackDirective { ttl: self.ttl }),
+                })
+            } else {
+                // After the FDv2 retry: deliver a delta.
+                Box::new(MockSynchronizer {
+                    results: VecDeque::from(vec![changeset(
+                        ChangeSetKind::Partial,
+                        "fdv2-back",
+                        Some("s".into()),
+                    )]),
+                    selectors_seen: no_selectors(),
+                    hang: false,
+                    fallback_directive: None,
+                })
+            }
         }
     }
 
@@ -1083,6 +1231,57 @@ mod tests {
         assert_eq!(sources.available_count(), 1);
     }
 
+    #[test]
+    fn fdv1_fallback_factory_starts_blocked() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // Only the FDv2 synchronizer is available; the FDv1 fallback is dormant.
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(!sources.is_current_fdv1_fallback());
+    }
+
+    #[test]
+    fn switch_to_and_back_from_fdv1_fallback() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // The directive activates only the FDv1 fallback.
+        sources.switch_to_fdv1_fallback();
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(sources.is_current_fdv1_fallback());
+
+        // Switching back restores the FDv2 synchronizer and re-blocks FDv1.
+        sources.switch_back_to_fdv2();
+        assert_eq!(sources.available_count(), 1);
+        sources.next_synchronizer();
+        assert!(!sources.is_current_fdv1_fallback());
+    }
+
+    #[test]
+    fn switch_back_unblocks_terminally_blocked_fdv2() {
+        let mut sources = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(vec![], no_selectors(), false),
+        ]);
+
+        // A terminal error blocks the only FDv2 synchronizer.
+        sources.next_synchronizer();
+        sources.block_current();
+        assert_eq!(sources.available_count(), 0);
+
+        // A fallback round-trip makes the FDv2 synchronizer usable again.
+        sources.switch_to_fdv1_fallback();
+        sources.switch_back_to_fdv2();
+        assert_eq!(sources.available_count(), 1);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn fallback_fires_after_sustained_interruption() {
         // No initializers; the prime interrupts then idles.
@@ -1219,5 +1418,86 @@ mod tests {
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fallback").is_some());
         assert!(store.read().flag("prime-recovered").is_some());
+    }
+
+    #[tokio::test]
+    async fn fallback_directive_switches_to_fdv1() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
+
+        // The FDv2 source reports a fallback directive with a zero TTL, so FDv2
+        // is never retried; the FDv1 fallback holds the basis.
+        let source_manager = SourceManager::new(vec![
+            fallback_directive_factory(Duration::ZERO),
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                false,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        run(
+            initializer_factories,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        )
+        .await;
+
+        // Switched to the FDv1 fallback and applied its basis.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fdv2_retry_reengages_after_ttl() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
+
+        // The FDv2 source reports a directive with a 60s TTL; the FDv1 fallback
+        // supplies a basis and then idles until FDv2 is retried.
+        let source_manager = SourceManager::new(vec![
+            Arc::new(FallbackThenDataFactory {
+                ttl: Duration::from_secs(60),
+                builds: AtomicUsize::new(0),
+            }) as Arc<dyn SynchronizerFactory>,
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                true,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        // Paused time auto-advances past the TTL, re-engaging FDv2.
+        let handle = tokio::spawn(run(
+            initializer_factories,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        ));
+        handle.await.unwrap();
+
+        // Fell back to FDv1, then re-engaged FDv2 once the TTL expired.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
+        assert!(store.read().flag("fdv2-back").is_some());
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -219,33 +219,50 @@ async fn run(
     let mut initialized = false;
     // Whether an initializer produced a full payload.
     let mut got_full = false;
+    let mut fdv2_retry_at: Option<Instant> = None;
 
-    // Initializer phase: try each until one yields a basis.
+    // Initializer phase: try each until one yields a basis or an FDv1 fallback
+    // directive.
     for factory in initializer_factories {
         let mut initializer = factory.create();
         let name = initializer.name().to_string();
         let mut shutdown = Box::pin(shutdown_receiver.recv()).fuse();
-        futures::select! {
+        let event = futures::select! {
             _ = shutdown => return,
-            event = initializer.run().fuse() => {
-                match event.result {
-                    FDv2SourceResult::ChangeSet(change_set) => {
-                        let is_full = matches!(change_set.kind, ChangeSetKind::Full);
-                        let has_basis = is_full && change_set.selector.is_some();
-                        if !matches!(change_set.kind, ChangeSetKind::None) {
-                            selector = change_set.selector.clone();
-                        }
-                        store.write().apply(change_set);
-                        if is_full {
-                            got_full = true;
-                        }
-                        if has_basis {
-                            break; // transition to synchronizer phase
-                        }
-                    }
-                    _ => debug!("{name} did not provide a basis"),
+            event = initializer.run().fuse() => event,
+        };
+
+        let FDv2SourceEvent {
+            result,
+            fdv1_fallback,
+        } = event;
+        let mut has_basis = false;
+        match result {
+            FDv2SourceResult::ChangeSet(change_set)
+                if !matches!(change_set.kind, ChangeSetKind::None) =>
+            {
+                let is_full = matches!(change_set.kind, ChangeSetKind::Full);
+                has_basis = is_full && change_set.selector.is_some();
+                selector = change_set.selector.clone();
+                store.write().apply(change_set);
+                if is_full {
+                    got_full = true;
                 }
             }
+            _ => debug!("{name} did not provide a basis"),
+        }
+        // An FDv1 fallback directive ends the initializer phase and switches
+        // to the fallback.
+        if let Some(fallback_directive) = fdv1_fallback {
+            info!("FDv2 falling back to the FDv1 protocol");
+            source_manager.switch_to_fdv1_fallback();
+            if fallback_directive.ttl != Duration::ZERO {
+                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
+            }
+            break;
+        }
+        if has_basis {
+            break;
         }
     }
 
@@ -255,7 +272,6 @@ async fn run(
     }
 
     // Synchronizer phase: rotate through synchronizers as the timers fire.
-    let mut fdv2_retry_at: Option<Instant> = None;
     let mut current = source_manager.next_synchronizer();
     while let Some(mut active) = current {
         let name = active.name().to_string();
@@ -323,13 +339,13 @@ async fn run(
                         }
                         FDv2SourceResult::Shutdown => return,
                     }
-                    // A fallback directive takes precedence over a terminal error.
-                    if let Some(directive) = fdv1_fallback {
+                    // An FDv1 fallback directive takes precedence over a terminal error.
+                    if let Some(fallback_directive) = fdv1_fallback {
                         if !source_manager.is_current_fdv1_fallback() {
                             info!("FDv2 falling back to the FDv1 protocol");
                             source_manager.switch_to_fdv1_fallback();
-                            if directive.ttl != Duration::ZERO {
-                                fdv2_retry_at = Some(Instant::now() + directive.ttl);
+                            if fallback_directive.ttl != Duration::ZERO {
+                                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
                             }
                             break;
                         }
@@ -421,6 +437,34 @@ mod tests {
 
         fn name(&self) -> &str {
             "mock-initializer"
+        }
+    }
+
+    /// An initializer that reports an FDv1 fallback directive with no TTL.
+    struct FallbackInitializer;
+
+    impl Initializer for FallbackInitializer {
+        fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent> {
+            Box::pin(async {
+                FDv2SourceEvent {
+                    result: interrupted(),
+                    fdv1_fallback: Some(FDv1FallbackDirective {
+                        ttl: Duration::ZERO,
+                    }),
+                }
+            })
+        }
+
+        fn name(&self) -> &str {
+            "fallback-initializer"
+        }
+    }
+
+    struct FallbackInitializerFactory;
+
+    impl InitializerFactory for FallbackInitializerFactory {
+        fn create(&self) -> Box<dyn Initializer> {
+            Box::new(FallbackInitializer)
         }
     }
 
@@ -1499,5 +1543,43 @@ mod tests {
         assert_eq!(*calls.lock().unwrap(), vec![true]);
         assert!(store.read().flag("from-fdv1").is_some());
         assert!(store.read().flag("fdv2-back").is_some());
+    }
+
+    #[tokio::test]
+    async fn initializer_fallback_directive_switches_to_fdv1() {
+        let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
+        let (init_complete, calls) = recording_init_complete();
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> =
+            vec![Arc::new(FallbackInitializerFactory)];
+
+        // The FDv2 synchronizer is never reached; the FDv1 fallback holds the basis.
+        let source_manager = SourceManager::new(vec![
+            sync_factory(vec![], no_selectors(), false),
+            fdv1_factory(
+                vec![changeset(
+                    ChangeSetKind::Full,
+                    "from-fdv1",
+                    Some("s".into()),
+                )],
+                no_selectors(),
+                false,
+            ),
+        ]);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+        run(
+            initializer_factories,
+            source_manager,
+            store.clone(),
+            init_complete,
+            shutdown_rx,
+            FALLBACK_TIMEOUT,
+            RECOVERY_TIMEOUT,
+        )
+        .await;
+
+        // The initializer's directive switched straight to the FDv1 fallback.
+        assert_eq!(*calls.lock().unwrap(), vec![true]);
+        assert!(store.read().flag("from-fdv1").is_some());
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -256,9 +256,7 @@ async fn run(
         if let Some(fallback_directive) = fdv1_fallback {
             info!("FDv2 falling back to the FDv1 protocol");
             source_manager.switch_to_fdv1_fallback();
-            if fallback_directive.ttl != Duration::ZERO {
-                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
-            }
+            fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
             break;
         }
         if has_basis {
@@ -368,9 +366,7 @@ async fn run(
                         if !source_manager.is_current_fdv1_fallback() {
                             info!("FDv2 falling back to the FDv1 protocol");
                             source_manager.switch_to_fdv1_fallback();
-                            if fallback_directive.ttl != Duration::ZERO {
-                                fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
-                            }
+                            fdv2_retry_at = Some(Instant::now() + fallback_directive.ttl);
                             break;
                         }
                     }
@@ -464,17 +460,18 @@ mod tests {
         }
     }
 
-    /// An initializer that reports an FDv1 fallback directive with no TTL.
-    struct FallbackInitializer;
+    /// An initializer that reports an FDv1 fallback directive with the given TTL.
+    struct FallbackInitializer {
+        ttl: Duration,
+    }
 
     impl Initializer for FallbackInitializer {
         fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent> {
-            Box::pin(async {
+            let ttl = self.ttl;
+            Box::pin(async move {
                 FDv2SourceEvent {
                     result: interrupted(),
-                    fdv1_fallback: Some(FDv1FallbackDirective {
-                        ttl: Duration::ZERO,
-                    }),
+                    fdv1_fallback: Some(FDv1FallbackDirective { ttl }),
                 }
             })
         }
@@ -484,11 +481,13 @@ mod tests {
         }
     }
 
-    struct FallbackInitializerFactory;
+    struct FallbackInitializerFactory {
+        ttl: Duration,
+    }
 
     impl InitializerFactory for FallbackInitializerFactory {
         fn create(&self) -> Box<dyn Initializer> {
-            Box::new(FallbackInitializer)
+            Box::new(FallbackInitializer { ttl: self.ttl })
         }
     }
 
@@ -1494,10 +1493,10 @@ mod tests {
         let (init_complete, calls) = recording_init_complete();
         let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
-        // The FDv2 source reports a fallback directive with a zero TTL, so FDv2
-        // is never retried; the FDv1 fallback holds the basis.
+        // The FDv2 source reports a fallback directive; the FDv1 fallback then
+        // supplies the basis and ends the run.
         let source_manager = SourceManager::new(vec![
-            fallback_directive_factory(Duration::ZERO),
+            fallback_directive_factory(Duration::from_secs(60)),
             fdv1_factory(
                 vec![changeset(
                     ChangeSetKind::Full,
@@ -1573,7 +1572,7 @@ mod tests {
     async fn fdv2_retry_survives_a_terminal_fdv1_fallback() {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
-        let initializers: Vec<Box<dyn Initializer>> = vec![];
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = vec![];
 
         // The FDv2 source reports a 60s directive; the FDv1 fallback then fails
         // terminally, blocking every source before the TTL expires.
@@ -1588,7 +1587,7 @@ mod tests {
 
         // Paused time advances past the TTL while no source is available.
         let handle = tokio::spawn(run(
-            initializers,
+            initializer_factories,
             source_manager,
             store.clone(),
             init_complete,
@@ -1608,9 +1607,12 @@ mod tests {
         let store = Arc::new(RwLock::new(InMemoryDataStore::new()));
         let (init_complete, calls) = recording_init_complete();
         let initializer_factories: Vec<Arc<dyn InitializerFactory>> =
-            vec![Arc::new(FallbackInitializerFactory)];
+            vec![Arc::new(FallbackInitializerFactory {
+                ttl: Duration::from_secs(60),
+            })];
 
-        // The FDv2 synchronizer is never reached; the FDv1 fallback holds the basis.
+        // The initializer's directive switches to the FDv1 fallback, which supplies
+        // the basis and ends the run.
         let source_manager = SourceManager::new(vec![
             sync_factory(vec![], no_selectors(), false),
             fdv1_factory(

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -221,8 +221,7 @@ async fn run(
     let mut got_full = false;
     let mut fdv2_retry_at: Option<Instant> = None;
 
-    // Initializer phase: try each until one yields a basis or an FDv1 fallback
-    // directive.
+    // Initializer phase: try each until one yields a basis or an FDv1 fallback directive.
     for factory in initializer_factories {
         let mut initializer = factory.create();
         let name = initializer.name().to_string();
@@ -251,8 +250,7 @@ async fn run(
             }
             _ => debug!("{name} did not provide a basis"),
         }
-        // An FDv1 fallback directive ends the initializer phase and switches
-        // to the fallback.
+        // An FDv1 fallback directive ends the initializer phase and activates the fallback.
         if let Some(fallback_directive) = fdv1_fallback {
             info!("FDv2 falling back to the FDv1 protocol");
             source_manager.switch_to_fdv1_fallback();
@@ -276,8 +274,8 @@ async fn run(
             Some(active) => active,
             None => {
                 // No synchronizer is available. While an FDv1 fallback directive's
-                // retry is pending, wait it out and return to FDv2 rather than exiting
-                // -- a blocked or terminal fallback must not strand the data system.
+                // retry is pending, wait it out and return to FDv2 rather than exiting.
+                // A blocked or terminal fallback must not strand the data system.
                 // With no retry pending, every source hit an unrecoverable error, so stop.
                 if fdv2_retry_at.is_none() {
                     break;
@@ -923,7 +921,7 @@ mod tests {
         .await;
 
         // Exactly three requests, and the one issued after the None changeset still
-        // carries "s1" -- the None must not reset the selector to None.
+        // carries "s1". The None must not reset the selector to None.
         let seen = selectors_seen.lock().unwrap();
         assert_eq!(*seen, vec![None, Some("s1".into()), Some("s1".into())]);
     }

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -76,9 +76,9 @@ fn parse_poll_body(body: &[u8]) -> FDv2SourceEvent {
                 }
                 return FDv2SourceEvent {
                     result: FDv2SourceResult::Goodbye,
-                    fdv1_fallback: g.protocol_fallback_ttl.map(|s| FDv1FallbackDirective {
-                        ttl: Duration::from_secs(s),
-                    }),
+                    fdv1_fallback: g
+                        .protocol_fallback_ttl
+                        .map(|s| FDv1FallbackDirective::from_ttl(Some(Duration::from_secs(s)))),
                 };
             }
             ProtocolResult::Error(ProtocolError::Server(err)) => {

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -1,14 +1,17 @@
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use rand::Rng;
 
 use crate::stores::change_set::ChangeSet;
 
 use super::model::Selector;
 
-pub(super) const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
-pub(super) const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
-pub(super) const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
+const FALLBACK_HEADER: &str = "X-LD-FD-Fallback";
+const FALLBACK_TTL_HEADER: &str = "X-LD-FD-Fallback-TTL";
+const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
+/// The longest server-supplied fallback TTL that is honored; longer values fall back to the default.
+const MAX_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ErrorKind {
@@ -30,6 +33,26 @@ pub(crate) struct FDv1FallbackDirective {
     pub(crate) ttl: Duration,
 }
 
+impl FDv1FallbackDirective {
+    /// Builds a directive from a server-supplied TTL. A value in the `(0, 1 hour]`
+    /// range is honored as-is; anything else -- absent, zero, or longer than an
+    /// hour -- uses a jittered one-hour default.
+    pub(super) fn from_ttl(ttl: Option<Duration>) -> Self {
+        let ttl = match ttl {
+            Some(t) if t > Duration::ZERO && t <= MAX_FALLBACK_TTL => t,
+            _ => jittered_default_ttl(),
+        };
+        Self { ttl }
+    }
+}
+
+/// Jitters the default TTL down by up to half so a fleet that all hits the default
+/// doesn't retry FDv2 in lockstep. Server-supplied TTLs are jittered upstream and
+/// are left untouched.
+fn jittered_default_ttl() -> Duration {
+    DEFAULT_FALLBACK_TTL.mul_f64(rand::rng().random_range(0.5..=1.0))
+}
+
 pub(super) fn read_fallback_directive<'a>(
     lookup: impl Fn(&str) -> Option<&'a str>,
 ) -> Option<FDv1FallbackDirective> {
@@ -39,9 +62,8 @@ pub(super) fn read_fallback_directive<'a>(
     }
     let ttl = lookup(FALLBACK_TTL_HEADER)
         .and_then(|s| s.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_FALLBACK_TTL);
-    Some(FDv1FallbackDirective { ttl })
+        .map(Duration::from_secs);
+    Some(FDv1FallbackDirective::from_ttl(ttl))
 }
 
 #[derive(Debug)]
@@ -79,6 +101,11 @@ mod tests {
         move |k| map.get(k).copied()
     }
 
+    // The default is jittered down by up to half, so it lands in [30 min, 1 hour].
+    fn assert_is_jittered_default(ttl: Duration) {
+        assert!(ttl <= DEFAULT_FALLBACK_TTL && ttl >= DEFAULT_FALLBACK_TTL / 2);
+    }
+
     #[test]
     fn fallback_absent_header_returns_none() {
         assert!(read_fallback_directive(headers(&[])).is_none());
@@ -93,7 +120,7 @@ mod tests {
     fn fallback_header_uppercase_true_uses_default_ttl() {
         let d =
             read_fallback_directive(headers(&[("X-LD-FD-Fallback", "TRUE")])).expect("directive");
-        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+        assert_is_jittered_default(d.ttl);
     }
 
     #[test]
@@ -113,6 +140,26 @@ mod tests {
             ("X-LD-FD-Fallback-TTL", "not-a-number"),
         ]))
         .expect("directive");
-        assert_eq!(d.ttl, DEFAULT_FALLBACK_TTL);
+        assert_is_jittered_default(d.ttl);
+    }
+
+    #[test]
+    fn fallback_ttl_zero_uses_default() {
+        let d = read_fallback_directive(headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "0"),
+        ]))
+        .expect("directive");
+        assert_is_jittered_default(d.ttl);
+    }
+
+    #[test]
+    fn fallback_ttl_longer_than_an_hour_uses_default() {
+        let d = read_fallback_directive(headers(&[
+            ("X-LD-FD-Fallback", "true"),
+            ("X-LD-FD-Fallback-TTL", "3601"),
+        ]))
+        .expect("directive");
+        assert_is_jittered_default(d.ttl);
     }
 }

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -121,9 +121,7 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizer<T> 
                 // the most recent response header.
                 let fallback = g
                     .protocol_fallback_ttl
-                    .map(|s| FDv1FallbackDirective {
-                        ttl: Duration::from_secs(s),
-                    })
+                    .map(|s| FDv1FallbackDirective::from_ttl(Some(Duration::from_secs(s))))
                     .or_else(|| self.latest_fdv1_fallback.clone());
                 self.drop_connection();
                 Some(FDv2SourceEvent {


### PR DESCRIPTION
## Summary

An initializer or synchronizer can report an FDv1 fallback directive alongside its result. When the orchestrator sees one, it blocks the FDv2 sources and switches to the FDv1 fallback synchronizer. A directive takes precedence over a terminal error reported by the same source.

The directive carries a TTL, which the orchestrator honors:

- A non-zero TTL schedules a retry that returns to FDv2 once it elapses.
- A zero TTL falls back indefinitely.

The FDv2 spec describes the fallback as terminal, but the SDK follows the TTL instead. The retry runs on an independent timer, so it still fires when no synchronizer is available. Without that, an FDv1 fallback that itself hit a terminal error would strand the data system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The FDv2 **data orchestrator** now reacts when initializers or synchronizers attach an **FDv1 fallback directive** on `FDv2SourceEvent`: it blocks FDv2 sources, activates the FDv1 fallback synchronizer (identified via new `SynchronizerFactory::is_fdv1_fallback()`), and schedules an **FDv2 retry** when the directive TTL elapses. The directive **wins over terminal errors** on the same event; if every source is blocked but a retry is still pending, the run **waits for the TTL** and calls `switch_back_to_fdv2()` instead of exiting.
> 
> **TTL handling** is centralized in `FDv1FallbackDirective::from_ttl()`: server values in `(0, 1 hour]` are kept; missing, zero, or over-long TTLs use a **jittered one-hour default** (to spread retries). Polling and streaming goodbye paths now build directives through that helper.
> 
> Broad **unit/integration tests** cover directive switching, TTL re-engagement, initializer-driven fallback, and recovery when FDv1 fails terminally while the retry timer is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5d47202c991a46368e6fec272ea5284b82480e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->