### PR TITLE
feat: Add the FDv2 data system configuration API

### DIFF
--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -14,6 +14,7 @@ use tokio::sync::{broadcast, Semaphore};
 use super::config::Config;
 use super::data_source_builders::BuildError as DataSourceError;
 use super::data_system::{DataSystem, FDv1DataSystem};
+use super::data_system_builders::BuildError as DataSystemError;
 use super::evaluation::{FlagDetail, FlagDetailConfig};
 use super::stores::store::DataStore;
 use super::stores::store_builders::BuildError as DataStoreError;
@@ -61,6 +62,12 @@ pub enum BuildError {
 
 impl From<DataSourceError> for BuildError {
     fn from(error: DataSourceError) -> Self {
+        Self::InvalidConfig(error.to_string())
+    }
+}
+
+impl From<DataSystemError> for BuildError {
+    fn from(error: DataSystemError) -> Self {
         Self::InvalidConfig(error.to_string())
     }
 }
@@ -184,13 +191,21 @@ impl Client {
         let event_processor =
             event_processor_builder.build(&endpoints, config.sdk_key(), tags.clone())?;
 
-        let mut data_source_builder = config.data_source_builder().to_owned();
-        data_source_builder.set_instance_id(instance_id);
-        let data_source = data_source_builder.build(&endpoints, config.sdk_key(), tags.clone())?;
-        let data_system: Arc<dyn DataSystem> = Arc::new(FDv1DataSystem::new(
-            data_source,
-            config.data_store_builder(),
-        )?);
+        let data_system: Arc<dyn DataSystem> = match config.data_system_builder() {
+            Some(data_system_builder) => {
+                data_system_builder.build(&endpoints, config.sdk_key(), tags.clone(), &instance_id)?
+            }
+            None => {
+                let mut data_source_builder = config.data_source_builder().to_owned();
+                data_source_builder.set_instance_id(instance_id);
+                let data_source =
+                    data_source_builder.build(&endpoints, config.sdk_key(), tags.clone())?;
+                Arc::new(FDv1DataSystem::new(
+                    data_source,
+                    config.data_store_builder(),
+                )?)
+            }
+        };
         let data_store = data_system.store();
 
         let events_default = EventsScope {

--- a/launchdarkly-server-sdk/src/client.rs
+++ b/launchdarkly-server-sdk/src/client.rs
@@ -192,9 +192,12 @@ impl Client {
             event_processor_builder.build(&endpoints, config.sdk_key(), tags.clone())?;
 
         let data_system: Arc<dyn DataSystem> = match config.data_system_builder() {
-            Some(data_system_builder) => {
-                data_system_builder.build(&endpoints, config.sdk_key(), tags.clone(), &instance_id)?
-            }
+            Some(data_system_builder) => data_system_builder.build(
+                &endpoints,
+                config.sdk_key(),
+                tags.as_deref(),
+                &instance_id,
+            )?,
             None => {
                 let mut data_source_builder = config.data_source_builder().to_owned();
                 data_source_builder.set_instance_id(instance_id);

--- a/launchdarkly-server-sdk/src/config.rs
+++ b/launchdarkly-server-sdk/src/config.rs
@@ -326,8 +326,27 @@ impl ConfigBuilder {
             Some(_data_store_builder) => self.data_store_builder.unwrap(),
         };
 
+        // The data system is optional; when set it supersedes the data source.
+        // Like the data source, it is ignored in offline or daemon mode.
+        let data_system_builder = match self.data_system_builder {
+            Some(_) if self.offline => {
+                warn!("Custom data system builders will be ignored when in offline mode");
+                None
+            }
+            Some(_) if self.daemon_mode => {
+                warn!("Custom data system builders will be ignored when in daemon mode");
+                None
+            }
+            other => other,
+        };
+
         let data_source_builder_result: Result<Box<dyn DataSourceFactory>, BuildError> =
             match self.data_source_builder {
+                None if data_system_builder.is_some() => Ok(Box::new(NullDataSourceBuilder::new())),
+                Some(_) if data_system_builder.is_some() => {
+                    warn!("Custom data source builders will be ignored when a data system is configured");
+                    Ok(Box::new(NullDataSourceBuilder::new()))
+                }
                 None if self.offline => Ok(Box::new(NullDataSourceBuilder::new())),
                 Some(_) if self.offline => {
                     warn!("Custom data source builders will be ignored when in offline mode");
@@ -366,20 +385,6 @@ impl ConfigBuilder {
                 )),
             };
         let data_source_builder = data_source_builder_result?;
-
-        // The data system is optional; when unset the client uses the data source above.
-        // Like that data source, it is ignored in offline or daemon mode.
-        let data_system_builder = match self.data_system_builder {
-            Some(_) if self.offline => {
-                warn!("Custom data system builders will be ignored when in offline mode");
-                None
-            }
-            Some(_) if self.daemon_mode => {
-                warn!("Custom data system builders will be ignored when in daemon mode");
-                None
-            }
-            other => other,
-        };
 
         let event_processor_builder_result: Result<Box<dyn EventProcessorFactory>, BuildError> =
             match self.event_processor_builder {

--- a/launchdarkly-server-sdk/src/config.rs
+++ b/launchdarkly-server-sdk/src/config.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 use crate::data_source_builders::{DataSourceFactory, NullDataSourceBuilder};
+use crate::data_system_builders::{DataSystemBuilder, DataSystemFactory};
 
 #[cfg(any(
     feature = "hyper-rustls-native-roots",
@@ -136,6 +137,7 @@ pub struct Config {
     service_endpoints_builder: ServiceEndpointsBuilder,
     data_store_builder: Box<dyn DataStoreFactory>,
     data_source_builder: Box<dyn DataSourceFactory>,
+    data_system_builder: Option<Box<dyn DataSystemFactory>>,
     event_processor_builder: Box<dyn EventProcessorFactory>,
     application_tag: Option<String>,
     instance_id: String,
@@ -162,6 +164,11 @@ impl Config {
     /// Returns the DataSourceFactory
     pub fn data_source_builder(&self) -> &dyn DataSourceFactory {
         self.data_source_builder.borrow()
+    }
+
+    /// Returns the DataSystemFactory, if an FDv2 data system was configured.
+    pub(crate) fn data_system_builder(&self) -> Option<&dyn DataSystemFactory> {
+        self.data_system_builder.as_deref()
     }
 
     /// Returns the EventProcessorFactory
@@ -212,6 +219,7 @@ pub struct ConfigBuilder {
     service_endpoints_builder: Option<ServiceEndpointsBuilder>,
     data_store_builder: Option<Box<dyn DataStoreFactory>>,
     data_source_builder: Option<Box<dyn DataSourceFactory>>,
+    data_system_builder: Option<Box<dyn DataSystemFactory>>,
     event_processor_builder: Option<Box<dyn EventProcessorFactory>>,
     application_info: Option<ApplicationInfo>,
     offline: bool,
@@ -226,6 +234,7 @@ impl ConfigBuilder {
             service_endpoints_builder: None,
             data_store_builder: None,
             data_source_builder: None,
+            data_system_builder: None,
             event_processor_builder: None,
             offline: false,
             daemon_mode: false,
@@ -255,6 +264,16 @@ impl ConfigBuilder {
     /// If offline mode is enabled, this data source will be ignored.
     pub fn data_source(mut self, builder: &dyn DataSourceFactory) -> Self {
         self.data_source_builder = Some(builder.to_owned());
+        self
+    }
+
+    /// Set the data system to use for this client.
+    ///
+    /// When set, the data system supersedes the [data_source](ConfigBuilder::data_source).
+    /// If offline mode is enabled, it will be ignored.
+    pub fn data_system(mut self, builder: &DataSystemBuilder) -> Self {
+        let factory: Box<dyn DataSystemFactory> = Box::new(builder.clone());
+        self.data_system_builder = Some(factory);
         self
     }
 
@@ -348,6 +367,20 @@ impl ConfigBuilder {
             };
         let data_source_builder = data_source_builder_result?;
 
+        // The data system is optional; when unset the client uses the data source above.
+        // Like that data source, it is ignored in offline or daemon mode.
+        let data_system_builder = match self.data_system_builder {
+            Some(_) if self.offline => {
+                warn!("Custom data system builders will be ignored when in offline mode");
+                None
+            }
+            Some(_) if self.daemon_mode => {
+                warn!("Custom data system builders will be ignored when in daemon mode");
+                None
+            }
+            other => other,
+        };
+
         let event_processor_builder_result: Result<Box<dyn EventProcessorFactory>, BuildError> =
             match self.event_processor_builder {
                 None if self.offline => Ok(Box::new(NullEventProcessorBuilder::new())),
@@ -401,6 +434,7 @@ impl ConfigBuilder {
             service_endpoints_builder,
             data_store_builder,
             data_source_builder,
+            data_system_builder,
             event_processor_builder,
             application_tag,
             instance_id,

--- a/launchdarkly-server-sdk/src/data_sources.rs
+++ b/launchdarkly-server-sdk/src/data_sources.rs
@@ -1,0 +1,16 @@
+//! Types for implementing custom FDv2 data sources.
+//!
+//! This module is experimental and not subject to semantic versioning. Its API
+//! may change in any release.
+
+pub use crate::data_system_builders::{
+    DataSourceBuildContext, FDv2InitializerConfig, FDv2SynchronizerConfig,
+};
+pub use crate::fdv2::data_system::{InitializerFactory, SynchronizerFactory};
+pub use crate::fdv2::model::{ChangeSetKind, Selector};
+pub use crate::fdv2::request_headers::RequestHeaders;
+pub use crate::fdv2::source::{
+    ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent, FDv2SourceResult, Initializer,
+    Synchronizer,
+};
+pub use crate::stores::change_set::{ChangeSet, ItemChange};

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -9,7 +9,7 @@ use crate::data_system::DataSystem;
 use crate::fdv2::data_system::{FDv2DataSystem, InitializerFactory, SynchronizerFactory};
 use crate::fdv2::fdv1_adapter::FDv1AdapterFactory;
 use crate::fdv2::polling::{PollingInitializerFactory, PollingSynchronizerFactory};
-use crate::fdv2::source::RequestHeaders;
+use crate::fdv2::request_headers::RequestHeaders;
 use crate::fdv2::streaming::StreamingSynchronizerFactory;
 use crate::service_endpoints::ServiceEndpoints;
 
@@ -366,7 +366,7 @@ pub(crate) trait DataSystemFactory {
         &self,
         endpoints: &ServiceEndpoints,
         sdk_key: &str,
-        tags: Option<String>,
+        tags: Option<&str>,
         instance_id: &str,
     ) -> Result<Arc<dyn DataSystem>, BuildError>;
 }
@@ -376,10 +376,10 @@ impl DataSystemFactory for DataSystemBuilder {
         &self,
         endpoints: &ServiceEndpoints,
         sdk_key: &str,
-        tags: Option<String>,
+        tags: Option<&str>,
         instance_id: &str,
     ) -> Result<Arc<dyn DataSystem>, BuildError> {
-        let headers = RequestHeaders::new(sdk_key, tags.as_deref(), instance_id);
+        let headers = RequestHeaders::new(sdk_key, tags, instance_id);
 
         let initializer_factories: Vec<Box<dyn InitializerFactory>> = self
             .initializers
@@ -398,9 +398,11 @@ impl DataSystemFactory for DataSystemBuilder {
         if let Some(fdv1_factory) = &self.fdv1_fallback {
             let mut fdv1_factory = (**fdv1_factory).to_owned();
             fdv1_factory.set_instance_id(instance_id.to_string());
-            let source = fdv1_factory.build(endpoints, sdk_key, tags).map_err(|e| {
-                BuildError::InvalidConfig(format!("failed to build FDv1 fallback source: {e}"))
-            })?;
+            let source = fdv1_factory
+                .build(endpoints, sdk_key, tags.map(|t| t.to_string()))
+                .map_err(|e| {
+                    BuildError::InvalidConfig(format!("failed to build FDv1 fallback source: {e}"))
+                })?;
             let adapter = FDv1AdapterFactory::new(Box::new(move || source.clone()));
             synchronizer_factories.push(Arc::new(adapter));
         }

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -1,0 +1,479 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use launchdarkly_sdk_transport::{HttpTransport, HyperTransport};
+use thiserror::Error;
+
+use crate::data_source_builders::{DataSourceFactory, StreamingDataSourceBuilder};
+use crate::data_system::DataSystem;
+use crate::fdv2::data_system::{FDv2DataSystem, InitializerFactory, SynchronizerFactory};
+use crate::fdv2::fdv1_adapter::FDv1AdapterFactory;
+use crate::fdv2::polling::{PollingInitializerFactory, PollingSynchronizerFactory};
+use crate::fdv2::source::RequestHeaders;
+use crate::fdv2::streaming::StreamingSynchronizerFactory;
+use crate::service_endpoints::ServiceEndpoints;
+
+const DEFAULT_INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const DEFAULT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_RECOVERY_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Error returned when a data system configuration cannot be built.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum BuildError {
+    /// The data system configuration was invalid.
+    #[error("data system config failed to build: {0}")]
+    InvalidConfig(String),
+}
+
+/// A configured FDv2 source usable as a synchronizer.
+pub(crate) trait FDv2SynchronizerConfig {
+    fn build_synchronizer(
+        &self,
+        endpoints: &ServiceEndpoints,
+        headers: &RequestHeaders,
+    ) -> Result<Box<dyn SynchronizerFactory>, BuildError>;
+
+    fn to_owned(&self) -> Box<dyn FDv2SynchronizerConfig>;
+}
+
+/// A configured FDv2 source usable as an initializer.
+pub(crate) trait FDv2InitializerConfig {
+    fn build_initializer(
+        &self,
+        endpoints: &ServiceEndpoints,
+        headers: &RequestHeaders,
+    ) -> Result<Box<dyn InitializerFactory>, BuildError>;
+
+    fn to_owned(&self) -> Box<dyn FDv2InitializerConfig>;
+}
+
+/// Builds the default HTTPS transport, or errors if no TLS feature is enabled.
+fn default_https_transport() -> Result<impl HttpTransport + 'static, BuildError> {
+    #[cfg(any(
+        feature = "hyper-rustls-native-roots",
+        feature = "hyper-rustls-webpki-roots",
+        feature = "native-tls"
+    ))]
+    {
+        HyperTransport::new_https().map_err(|e| {
+            BuildError::InvalidConfig(format!("failed to create default https transport: {e:?}"))
+        })
+    }
+    #[cfg(not(any(
+        feature = "hyper-rustls-native-roots",
+        feature = "hyper-rustls-webpki-roots",
+        feature = "native-tls"
+    )))]
+    {
+        Err::<HyperTransport, _>(BuildError::InvalidConfig(
+            "https connector required when hyper-rustls-native-roots, hyper-rustls-webpki-roots, or native-tls features are disabled".into(),
+        ))
+    }
+}
+
+/// Configures an FDv2 streaming source, which can only act as a synchronizer.
+#[derive(Clone)]
+pub struct FDv2StreamingBuilder<T: HttpTransport = HyperTransport> {
+    initial_reconnect_delay: Duration,
+    base_url: Option<String>,
+    transport: Option<T>,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2StreamingBuilder<T> {
+    /// Creates a builder with default values.
+    pub fn new() -> Self {
+        Self {
+            initial_reconnect_delay: DEFAULT_INITIAL_RECONNECT_DELAY,
+            base_url: None,
+            transport: None,
+        }
+    }
+
+    /// Sets the initial reconnect delay for the streaming connection.
+    pub fn initial_reconnect_delay(&mut self, duration: Duration) -> &mut Self {
+        self.initial_reconnect_delay = duration;
+        self
+    }
+
+    /// Sets the streaming base URL, overriding the configured service endpoints.
+    pub fn base_url(&mut self, url: &str) -> &mut Self {
+        self.base_url = Some(url.to_string());
+        self
+    }
+
+    /// Sets the transport to use, instead of the default HTTPS transport.
+    pub fn transport(&mut self, transport: T) -> &mut Self {
+        self.transport = Some(transport);
+        self
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2SynchronizerConfig
+    for FDv2StreamingBuilder<T>
+{
+    fn build_synchronizer(
+        &self,
+        endpoints: &ServiceEndpoints,
+        headers: &RequestHeaders,
+    ) -> Result<Box<dyn SynchronizerFactory>, BuildError> {
+        let base_url = self
+            .base_url
+            .clone()
+            .unwrap_or_else(|| endpoints.streaming_base_url().to_string());
+        let factory: Box<dyn SynchronizerFactory> = match &self.transport {
+            Some(transport) => Box::new(StreamingSynchronizerFactory::new(
+                transport.clone(),
+                base_url,
+                headers.clone(),
+                self.initial_reconnect_delay,
+            )),
+            None => Box::new(StreamingSynchronizerFactory::new(
+                default_https_transport()?,
+                base_url,
+                headers.clone(),
+                self.initial_reconnect_delay,
+            )),
+        };
+        Ok(factory)
+    }
+
+    fn to_owned(&self) -> Box<dyn FDv2SynchronizerConfig> {
+        Box::new(self.clone())
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> Default for FDv2StreamingBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configures an FDv2 polling source, which can act as an initializer or a synchronizer.
+#[derive(Clone)]
+pub struct FDv2PollingBuilder<T: HttpTransport = HyperTransport> {
+    poll_interval: Duration,
+    base_url: Option<String>,
+    transport: Option<T>,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2PollingBuilder<T> {
+    /// Creates a builder with default values.
+    pub fn new() -> Self {
+        Self {
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            base_url: None,
+            transport: None,
+        }
+    }
+
+    /// Sets the interval between polling requests, with an effective minimum of 30 seconds.
+    pub fn poll_interval(&mut self, poll_interval: Duration) -> &mut Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    /// Sets the polling base URL, overriding the configured service endpoints.
+    pub fn base_url(&mut self, url: &str) -> &mut Self {
+        self.base_url = Some(url.to_string());
+        self
+    }
+
+    /// Sets the transport to use, instead of the default HTTPS transport.
+    pub fn transport(&mut self, transport: T) -> &mut Self {
+        self.transport = Some(transport);
+        self
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2SynchronizerConfig
+    for FDv2PollingBuilder<T>
+{
+    fn build_synchronizer(
+        &self,
+        endpoints: &ServiceEndpoints,
+        headers: &RequestHeaders,
+    ) -> Result<Box<dyn SynchronizerFactory>, BuildError> {
+        let base_url = self
+            .base_url
+            .clone()
+            .unwrap_or_else(|| endpoints.polling_base_url().to_string());
+        let factory: Box<dyn SynchronizerFactory> = match &self.transport {
+            Some(transport) => Box::new(PollingSynchronizerFactory::new(
+                transport.clone(),
+                base_url,
+                headers.clone(),
+                self.poll_interval,
+            )),
+            None => Box::new(PollingSynchronizerFactory::new(
+                default_https_transport()?,
+                base_url,
+                headers.clone(),
+                self.poll_interval,
+            )),
+        };
+        Ok(factory)
+    }
+
+    fn to_owned(&self) -> Box<dyn FDv2SynchronizerConfig> {
+        Box::new(self.clone())
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2InitializerConfig
+    for FDv2PollingBuilder<T>
+{
+    fn build_initializer(
+        &self,
+        endpoints: &ServiceEndpoints,
+        headers: &RequestHeaders,
+    ) -> Result<Box<dyn InitializerFactory>, BuildError> {
+        let base_url = self
+            .base_url
+            .clone()
+            .unwrap_or_else(|| endpoints.polling_base_url().to_string());
+        let factory: Box<dyn InitializerFactory> = match &self.transport {
+            Some(transport) => Box::new(PollingInitializerFactory::new(
+                transport.clone(),
+                base_url,
+                headers.clone(),
+            )),
+            None => Box::new(PollingInitializerFactory::new(
+                default_https_transport()?,
+                base_url,
+                headers.clone(),
+            )),
+        };
+        Ok(factory)
+    }
+
+    fn to_owned(&self) -> Box<dyn FDv2InitializerConfig> {
+        Box::new(self.clone())
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> Default for FDv2PollingBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configures the FDv2 data system.
+pub struct DataSystemBuilder {
+    initializers: Vec<Box<dyn FDv2InitializerConfig>>,
+    synchronizers: Vec<Box<dyn FDv2SynchronizerConfig>>,
+    fdv1_fallback: Option<Box<dyn DataSourceFactory>>,
+    fallback_timeout: Duration,
+    recovery_timeout: Duration,
+}
+
+impl Clone for DataSystemBuilder {
+    fn clone(&self) -> Self {
+        Self {
+            initializers: self.initializers.iter().map(|c| (**c).to_owned()).collect(),
+            synchronizers: self
+                .synchronizers
+                .iter()
+                .map(|c| (**c).to_owned())
+                .collect(),
+            fdv1_fallback: self.fdv1_fallback.as_ref().map(|f| (**f).to_owned()),
+            fallback_timeout: self.fallback_timeout,
+            recovery_timeout: self.recovery_timeout,
+        }
+    }
+}
+
+impl DataSystemBuilder {
+    /// Creates an empty builder; the caller adds sources explicitly.
+    pub fn custom() -> Self {
+        Self {
+            initializers: Vec::new(),
+            synchronizers: Vec::new(),
+            fdv1_fallback: None,
+            fallback_timeout: DEFAULT_FALLBACK_TIMEOUT,
+            recovery_timeout: DEFAULT_RECOVERY_TIMEOUT,
+        }
+    }
+
+    /// Appends a polling initializer.
+    pub fn initializer<T: HttpTransport + Clone + Send + Sync + 'static>(
+        &mut self,
+        source: FDv2PollingBuilder<T>,
+    ) -> &mut Self {
+        self.initializers.push(Box::new(source));
+        self
+    }
+
+    /// Appends a streaming synchronizer, ordered after any already added.
+    pub fn streaming_synchronizer<T: HttpTransport + Clone + Send + Sync + 'static>(
+        &mut self,
+        source: FDv2StreamingBuilder<T>,
+    ) -> &mut Self {
+        self.synchronizers.push(Box::new(source));
+        self
+    }
+
+    /// Appends a polling synchronizer, ordered after any already added.
+    pub fn polling_synchronizer<T: HttpTransport + Clone + Send + Sync + 'static>(
+        &mut self,
+        source: FDv2PollingBuilder<T>,
+    ) -> &mut Self {
+        self.synchronizers.push(Box::new(source));
+        self
+    }
+
+    /// Sets the FDv1 source used as a last-resort fallback.
+    pub fn fdv1_fallback(&mut self, factory: &dyn DataSourceFactory) -> &mut Self {
+        self.fdv1_fallback = Some(factory.to_owned());
+        self
+    }
+
+    /// Disables the FDv1 fallback.
+    pub fn disable_fdv1_fallback(&mut self) -> &mut Self {
+        self.fdv1_fallback = None;
+        self
+    }
+
+    /// Sets how long the active synchronizer may stay interrupted before failing over.
+    pub fn fallback_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.fallback_timeout = timeout;
+        self
+    }
+
+    /// Sets how long a fallback synchronizer must run before recovering to the primary.
+    pub fn recovery_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.recovery_timeout = timeout;
+        self
+    }
+}
+
+impl Default for DataSystemBuilder {
+    /// The recommended data system setup.
+    fn default() -> Self {
+        let mut builder = Self::custom();
+        builder.initializer(FDv2PollingBuilder::<HyperTransport>::new());
+        builder.streaming_synchronizer(FDv2StreamingBuilder::<HyperTransport>::new());
+        builder.polling_synchronizer(FDv2PollingBuilder::<HyperTransport>::new());
+        builder.fdv1_fallback(&StreamingDataSourceBuilder::<HyperTransport>::new());
+        builder
+    }
+}
+
+/// Builds the internal FDv2 data system from a configured source set.
+pub(crate) trait DataSystemFactory {
+    fn build(
+        &self,
+        endpoints: &ServiceEndpoints,
+        sdk_key: &str,
+        tags: Option<String>,
+        instance_id: &str,
+    ) -> Result<Arc<dyn DataSystem>, BuildError>;
+}
+
+impl DataSystemFactory for DataSystemBuilder {
+    fn build(
+        &self,
+        endpoints: &ServiceEndpoints,
+        sdk_key: &str,
+        tags: Option<String>,
+        instance_id: &str,
+    ) -> Result<Arc<dyn DataSystem>, BuildError> {
+        let headers = RequestHeaders::new(sdk_key, tags.as_deref(), instance_id);
+
+        let initializer_factories: Vec<Box<dyn InitializerFactory>> = self
+            .initializers
+            .iter()
+            .map(|c| c.build_initializer(endpoints, &headers))
+            .collect::<Result<_, _>>()?;
+
+        let mut synchronizer_factories: Vec<Arc<dyn SynchronizerFactory>> = self
+            .synchronizers
+            .iter()
+            .map(|c| c.build_synchronizer(endpoints, &headers).map(Arc::from))
+            .collect::<Result<_, _>>()?;
+
+        // Build the FDv1 fallback source once and wrap it as a synchronizer; the
+        // adapter re-subscribes it whenever the fallback activates.
+        if let Some(fdv1_factory) = &self.fdv1_fallback {
+            let mut fdv1_factory = (**fdv1_factory).to_owned();
+            fdv1_factory.set_instance_id(instance_id.to_string());
+            let source = fdv1_factory.build(endpoints, sdk_key, tags).map_err(|e| {
+                BuildError::InvalidConfig(format!("failed to build FDv1 fallback source: {e}"))
+            })?;
+            let adapter = FDv1AdapterFactory::new(Box::new(move || source.clone()));
+            synchronizer_factories.push(Arc::new(adapter));
+        }
+
+        let system: Arc<dyn DataSystem> = Arc::new(FDv2DataSystem::new(
+            initializer_factories,
+            synchronizer_factories,
+            self.fallback_timeout,
+            self.recovery_timeout,
+        ));
+        Ok(system)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_starts_empty() {
+        let builder = DataSystemBuilder::custom();
+
+        assert!(builder.initializers.is_empty());
+        assert!(builder.synchronizers.is_empty());
+        assert!(builder.fdv1_fallback.is_none());
+        assert_eq!(builder.fallback_timeout, DEFAULT_FALLBACK_TIMEOUT);
+        assert_eq!(builder.recovery_timeout, DEFAULT_RECOVERY_TIMEOUT);
+    }
+
+    #[test]
+    fn default_has_recommended_sources() {
+        let builder = DataSystemBuilder::default();
+
+        assert_eq!(builder.initializers.len(), 1);
+        assert_eq!(builder.synchronizers.len(), 2);
+        assert!(builder.fdv1_fallback.is_some());
+    }
+
+    #[test]
+    fn disable_fdv1_fallback_clears_it() {
+        let mut builder = DataSystemBuilder::default();
+        assert!(builder.fdv1_fallback.is_some());
+
+        builder.disable_fdv1_fallback();
+
+        assert!(builder.fdv1_fallback.is_none());
+    }
+
+    #[test]
+    fn timeouts_are_configurable() {
+        let mut builder = DataSystemBuilder::custom();
+
+        builder.fallback_timeout(Duration::from_secs(7));
+        builder.recovery_timeout(Duration::from_secs(11));
+
+        assert_eq!(builder.fallback_timeout, Duration::from_secs(7));
+        assert_eq!(builder.recovery_timeout, Duration::from_secs(11));
+    }
+
+    #[test]
+    fn builders_build_factories_with_default_transport() {
+        let endpoints = crate::ServiceEndpointsBuilder::new().build().unwrap();
+        let headers = RequestHeaders::new("sdk-key", None, "test-instance");
+
+        // Each source builds a factory off the default HTTPS transport.
+        assert!(FDv2StreamingBuilder::<HyperTransport>::new()
+            .build_synchronizer(&endpoints, &headers)
+            .is_ok());
+        assert!(FDv2PollingBuilder::<HyperTransport>::new()
+            .build_synchronizer(&endpoints, &headers)
+            .is_ok());
+        assert!(FDv2PollingBuilder::<HyperTransport>::new()
+            .build_initializer(&endpoints, &headers)
+            .is_ok());
+    }
+}

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use launchdarkly_sdk_transport::{HttpTransport, HyperTransport};
 use thiserror::Error;
 
-use crate::data_source_builders::{DataSourceFactory, StreamingDataSourceBuilder};
+use crate::data_source_builders::{DataSourceFactory, PollingDataSourceBuilder};
 use crate::data_system::DataSystem;
 use crate::fdv2::data_system::{FDv2DataSystem, InitializerFactory, SynchronizerFactory};
 use crate::fdv2::fdv1_adapter::FDv1AdapterFactory;
@@ -330,7 +330,7 @@ impl Default for DataSystemBuilder {
         builder.initializer(FDv2PollingBuilder::<HyperTransport>::new());
         builder.synchronizer(FDv2StreamingBuilder::<HyperTransport>::new());
         builder.synchronizer(FDv2PollingBuilder::<HyperTransport>::new());
-        builder.fdv1_fallback(&StreamingDataSourceBuilder::<HyperTransport>::new());
+        builder.fdv1_fallback(&PollingDataSourceBuilder::<HyperTransport>::new());
         builder
     }
 }

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -419,6 +419,9 @@ impl DataSystemFactory for DataSystemBuilder {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use launchdarkly_sdk_transport::{Request, ResponseFuture};
+
     use super::*;
 
     #[test]
@@ -462,7 +465,43 @@ mod tests {
         assert_eq!(builder.recovery_timeout, Duration::from_secs(11));
     }
 
+    #[derive(Debug, Clone)]
+    struct TestTransport;
+
+    impl HttpTransport for TestTransport {
+        fn request(&self, _request: Request<Option<Bytes>>) -> ResponseFuture {
+            unreachable!();
+        }
+    }
+
     #[test]
+    fn builders_build_factories_with_injected_transport() {
+        let endpoints = crate::ServiceEndpointsBuilder::new().build().unwrap();
+        let headers = RequestHeaders::new("sdk-key", None, "test-instance");
+
+        // Each source builds a factory from a configured transport.
+        assert!(FDv2StreamingBuilder::<TestTransport>::new()
+            .transport(TestTransport)
+            .build_synchronizer(&endpoints, &headers)
+            .is_ok());
+        assert!(FDv2PollingBuilder::<TestTransport>::new()
+            .transport(TestTransport)
+            .build_synchronizer(&endpoints, &headers)
+            .is_ok());
+        assert!(FDv2PollingBuilder::<TestTransport>::new()
+            .transport(TestTransport)
+            .build_initializer(&endpoints, &headers)
+            .is_ok());
+    }
+
+    // The default path builds a real HTTPS transport, which needs a TLS backend,
+    // so this only runs where one of those features is enabled.
+    #[test]
+    #[cfg(any(
+        feature = "hyper-rustls-native-roots",
+        feature = "hyper-rustls-webpki-roots",
+        feature = "native-tls"
+    ))]
     fn builders_build_factories_with_default_transport() {
         let endpoints = crate::ServiceEndpointsBuilder::new().build().unwrap();
         let headers = RequestHeaders::new("sdk-key", None, "test-instance");

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -264,8 +264,6 @@ pub struct DataSystemBuilder {
     initializers: Vec<Box<dyn FDv2InitializerConfig>>,
     synchronizers: Vec<Box<dyn FDv2SynchronizerConfig>>,
     fdv1_fallback: Option<Box<dyn DataSourceFactory>>,
-    fallback_timeout: Duration,
-    recovery_timeout: Duration,
 }
 
 impl Clone for DataSystemBuilder {
@@ -278,8 +276,6 @@ impl Clone for DataSystemBuilder {
                 .map(|c| (**c).to_owned())
                 .collect(),
             fdv1_fallback: self.fdv1_fallback.as_ref().map(|f| (**f).to_owned()),
-            fallback_timeout: self.fallback_timeout,
-            recovery_timeout: self.recovery_timeout,
         }
     }
 }
@@ -291,8 +287,6 @@ impl DataSystemBuilder {
             initializers: Vec::new(),
             synchronizers: Vec::new(),
             fdv1_fallback: None,
-            fallback_timeout: DEFAULT_FALLBACK_TIMEOUT,
-            recovery_timeout: DEFAULT_RECOVERY_TIMEOUT,
         }
     }
 
@@ -332,18 +326,6 @@ impl DataSystemBuilder {
     /// Disables the FDv1 fallback.
     pub fn disable_fdv1_fallback(&mut self) -> &mut Self {
         self.fdv1_fallback = None;
-        self
-    }
-
-    /// Sets how long the active synchronizer may stay interrupted before failing over.
-    pub fn fallback_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.fallback_timeout = timeout;
-        self
-    }
-
-    /// Sets how long a fallback synchronizer must run before recovering to the primary.
-    pub fn recovery_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.recovery_timeout = timeout;
         self
     }
 }
@@ -410,8 +392,8 @@ impl DataSystemFactory for DataSystemBuilder {
         let system: Arc<dyn DataSystem> = Arc::new(FDv2DataSystem::new(
             initializer_factories,
             synchronizer_factories,
-            self.fallback_timeout,
-            self.recovery_timeout,
+            DEFAULT_FALLBACK_TIMEOUT,
+            DEFAULT_RECOVERY_TIMEOUT,
         ));
         Ok(system)
     }
@@ -431,8 +413,6 @@ mod tests {
         assert!(builder.initializers.is_empty());
         assert!(builder.synchronizers.is_empty());
         assert!(builder.fdv1_fallback.is_none());
-        assert_eq!(builder.fallback_timeout, DEFAULT_FALLBACK_TIMEOUT);
-        assert_eq!(builder.recovery_timeout, DEFAULT_RECOVERY_TIMEOUT);
     }
 
     #[test]
@@ -452,17 +432,6 @@ mod tests {
         builder.disable_fdv1_fallback();
 
         assert!(builder.fdv1_fallback.is_none());
-    }
-
-    #[test]
-    fn timeouts_are_configurable() {
-        let mut builder = DataSystemBuilder::custom();
-
-        builder.fallback_timeout(Duration::from_secs(7));
-        builder.recovery_timeout(Duration::from_secs(11));
-
-        assert_eq!(builder.fallback_timeout, Duration::from_secs(7));
-        assert_eq!(builder.recovery_timeout, Duration::from_secs(11));
     }
 
     #[derive(Debug, Clone)]

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -27,25 +27,36 @@ pub enum BuildError {
     InvalidConfig(String),
 }
 
+/// The inputs a data source needs to build itself.
+#[non_exhaustive]
+pub struct DataSourceBuildContext<'a> {
+    /// The configured service endpoints.
+    pub endpoints: &'a ServiceEndpoints,
+    /// The HTTP headers to attach to every request.
+    pub headers: &'a RequestHeaders,
+}
+
 /// A configured FDv2 source usable as a synchronizer.
-pub(crate) trait FDv2SynchronizerConfig {
+pub trait FDv2SynchronizerConfig {
+    /// Builds a synchronizer factory from this configuration.
     fn build_synchronizer(
         &self,
-        endpoints: &ServiceEndpoints,
-        headers: &RequestHeaders,
+        context: &DataSourceBuildContext,
     ) -> Result<Box<dyn SynchronizerFactory>, BuildError>;
 
+    /// Clones this configuration into a new box.
     fn to_owned(&self) -> Box<dyn FDv2SynchronizerConfig>;
 }
 
 /// A configured FDv2 source usable as an initializer.
-pub(crate) trait FDv2InitializerConfig {
+pub trait FDv2InitializerConfig {
+    /// Builds an initializer factory from this configuration.
     fn build_initializer(
         &self,
-        endpoints: &ServiceEndpoints,
-        headers: &RequestHeaders,
+        context: &DataSourceBuildContext,
     ) -> Result<Box<dyn InitializerFactory>, BuildError>;
 
+    /// Clones this configuration into a new box.
     fn to_owned(&self) -> Box<dyn FDv2InitializerConfig>;
 }
 
@@ -115,24 +126,23 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2SynchronizerConfig
 {
     fn build_synchronizer(
         &self,
-        endpoints: &ServiceEndpoints,
-        headers: &RequestHeaders,
+        context: &DataSourceBuildContext,
     ) -> Result<Box<dyn SynchronizerFactory>, BuildError> {
         let base_url = self
             .base_url
             .clone()
-            .unwrap_or_else(|| endpoints.streaming_base_url().to_string());
+            .unwrap_or_else(|| context.endpoints.streaming_base_url().to_string());
         let factory: Box<dyn SynchronizerFactory> = match &self.transport {
             Some(transport) => Box::new(StreamingSynchronizerFactory::new(
                 transport.clone(),
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
                 self.initial_reconnect_delay,
             )),
             None => Box::new(StreamingSynchronizerFactory::new(
                 default_https_transport()?,
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
                 self.initial_reconnect_delay,
             )),
         };
@@ -192,24 +202,23 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2SynchronizerConfig
 {
     fn build_synchronizer(
         &self,
-        endpoints: &ServiceEndpoints,
-        headers: &RequestHeaders,
+        context: &DataSourceBuildContext,
     ) -> Result<Box<dyn SynchronizerFactory>, BuildError> {
         let base_url = self
             .base_url
             .clone()
-            .unwrap_or_else(|| endpoints.polling_base_url().to_string());
+            .unwrap_or_else(|| context.endpoints.polling_base_url().to_string());
         let factory: Box<dyn SynchronizerFactory> = match &self.transport {
             Some(transport) => Box::new(PollingSynchronizerFactory::new(
                 transport.clone(),
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
                 self.poll_interval,
             )),
             None => Box::new(PollingSynchronizerFactory::new(
                 default_https_transport()?,
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
                 self.poll_interval,
             )),
         };
@@ -226,23 +235,22 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> FDv2InitializerConfig
 {
     fn build_initializer(
         &self,
-        endpoints: &ServiceEndpoints,
-        headers: &RequestHeaders,
+        context: &DataSourceBuildContext,
     ) -> Result<Box<dyn InitializerFactory>, BuildError> {
         let base_url = self
             .base_url
             .clone()
-            .unwrap_or_else(|| endpoints.polling_base_url().to_string());
+            .unwrap_or_else(|| context.endpoints.polling_base_url().to_string());
         let factory: Box<dyn InitializerFactory> = match &self.transport {
             Some(transport) => Box::new(PollingInitializerFactory::new(
                 transport.clone(),
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
             )),
             None => Box::new(PollingInitializerFactory::new(
                 default_https_transport()?,
                 base_url,
-                headers.clone(),
+                context.headers.clone(),
             )),
         };
         Ok(factory)
@@ -290,29 +298,14 @@ impl DataSystemBuilder {
         }
     }
 
-    /// Appends a polling initializer.
-    pub fn initializer<T: HttpTransport + Clone + Send + Sync + 'static>(
-        &mut self,
-        source: FDv2PollingBuilder<T>,
-    ) -> &mut Self {
+    /// Appends an initializer, called before the synchronizers in configuration order.
+    pub fn initializer(&mut self, source: impl FDv2InitializerConfig + 'static) -> &mut Self {
         self.initializers.push(Box::new(source));
         self
     }
 
-    /// Appends a streaming synchronizer, ordered after any already added.
-    pub fn streaming_synchronizer<T: HttpTransport + Clone + Send + Sync + 'static>(
-        &mut self,
-        source: FDv2StreamingBuilder<T>,
-    ) -> &mut Self {
-        self.synchronizers.push(Box::new(source));
-        self
-    }
-
-    /// Appends a polling synchronizer, ordered after any already added.
-    pub fn polling_synchronizer<T: HttpTransport + Clone + Send + Sync + 'static>(
-        &mut self,
-        source: FDv2PollingBuilder<T>,
-    ) -> &mut Self {
+    /// Appends a synchronizer, ordered after any already added.
+    pub fn synchronizer(&mut self, source: impl FDv2SynchronizerConfig + 'static) -> &mut Self {
         self.synchronizers.push(Box::new(source));
         self
     }
@@ -335,8 +328,8 @@ impl Default for DataSystemBuilder {
     fn default() -> Self {
         let mut builder = Self::custom();
         builder.initializer(FDv2PollingBuilder::<HyperTransport>::new());
-        builder.streaming_synchronizer(FDv2StreamingBuilder::<HyperTransport>::new());
-        builder.polling_synchronizer(FDv2PollingBuilder::<HyperTransport>::new());
+        builder.synchronizer(FDv2StreamingBuilder::<HyperTransport>::new());
+        builder.synchronizer(FDv2PollingBuilder::<HyperTransport>::new());
         builder.fdv1_fallback(&StreamingDataSourceBuilder::<HyperTransport>::new());
         builder
     }
@@ -362,17 +355,21 @@ impl DataSystemFactory for DataSystemBuilder {
         instance_id: &str,
     ) -> Result<Arc<dyn DataSystem>, BuildError> {
         let headers = RequestHeaders::new(sdk_key, tags, instance_id);
+        let context = DataSourceBuildContext {
+            endpoints,
+            headers: &headers,
+        };
 
         let initializer_factories: Vec<Arc<dyn InitializerFactory>> = self
             .initializers
             .iter()
-            .map(|c| c.build_initializer(endpoints, &headers).map(Arc::from))
+            .map(|c| c.build_initializer(&context).map(Arc::from))
             .collect::<Result<_, _>>()?;
 
         let mut synchronizer_factories: Vec<Arc<dyn SynchronizerFactory>> = self
             .synchronizers
             .iter()
-            .map(|c| c.build_synchronizer(endpoints, &headers).map(Arc::from))
+            .map(|c| c.build_synchronizer(&context).map(Arc::from))
             .collect::<Result<_, _>>()?;
 
         // Build the FDv1 fallback source once and wrap it as a synchronizer; the
@@ -447,19 +444,23 @@ mod tests {
     fn builders_build_factories_with_injected_transport() {
         let endpoints = crate::ServiceEndpointsBuilder::new().build().unwrap();
         let headers = RequestHeaders::new("sdk-key", None, "test-instance");
+        let context = DataSourceBuildContext {
+            endpoints: &endpoints,
+            headers: &headers,
+        };
 
         // Each source builds a factory from a configured transport.
         assert!(FDv2StreamingBuilder::<TestTransport>::new()
             .transport(TestTransport)
-            .build_synchronizer(&endpoints, &headers)
+            .build_synchronizer(&context)
             .is_ok());
         assert!(FDv2PollingBuilder::<TestTransport>::new()
             .transport(TestTransport)
-            .build_synchronizer(&endpoints, &headers)
+            .build_synchronizer(&context)
             .is_ok());
         assert!(FDv2PollingBuilder::<TestTransport>::new()
             .transport(TestTransport)
-            .build_initializer(&endpoints, &headers)
+            .build_initializer(&context)
             .is_ok());
     }
 
@@ -474,16 +475,20 @@ mod tests {
     fn builders_build_factories_with_default_transport() {
         let endpoints = crate::ServiceEndpointsBuilder::new().build().unwrap();
         let headers = RequestHeaders::new("sdk-key", None, "test-instance");
+        let context = DataSourceBuildContext {
+            endpoints: &endpoints,
+            headers: &headers,
+        };
 
         // Each source builds a factory off the default HTTPS transport.
         assert!(FDv2StreamingBuilder::<HyperTransport>::new()
-            .build_synchronizer(&endpoints, &headers)
+            .build_synchronizer(&context)
             .is_ok());
         assert!(FDv2PollingBuilder::<HyperTransport>::new()
-            .build_synchronizer(&endpoints, &headers)
+            .build_synchronizer(&context)
             .is_ok());
         assert!(FDv2PollingBuilder::<HyperTransport>::new()
-            .build_initializer(&endpoints, &headers)
+            .build_initializer(&context)
             .is_ok());
     }
 }

--- a/launchdarkly-server-sdk/src/data_system_builders.rs
+++ b/launchdarkly-server-sdk/src/data_system_builders.rs
@@ -381,10 +381,10 @@ impl DataSystemFactory for DataSystemBuilder {
     ) -> Result<Arc<dyn DataSystem>, BuildError> {
         let headers = RequestHeaders::new(sdk_key, tags, instance_id);
 
-        let initializer_factories: Vec<Box<dyn InitializerFactory>> = self
+        let initializer_factories: Vec<Arc<dyn InitializerFactory>> = self
             .initializers
             .iter()
-            .map(|c| c.build_initializer(endpoints, &headers))
+            .map(|c| c.build_initializer(endpoints, &headers).map(Arc::from))
             .collect::<Result<_, _>>()?;
 
         let mut synchronizer_factories: Vec<Arc<dyn SynchronizerFactory>> = self

--- a/launchdarkly-server-sdk/src/fdv2/data_system.rs
+++ b/launchdarkly-server-sdk/src/fdv2/data_system.rs
@@ -13,12 +13,14 @@ use super::model::{ChangeSetKind, Selector};
 use super::source::{FDv2SourceEvent, FDv2SourceResult, Initializer, Synchronizer};
 
 /// Produces a fresh initializer each time the orchestrator starts a run.
-pub(crate) trait InitializerFactory: Send + Sync {
+pub trait InitializerFactory: Send + Sync {
+    /// Builds a new initializer instance.
     fn create(&self) -> Box<dyn Initializer>;
 }
 
 /// Produces a fresh synchronizer each time the orchestrator starts a run.
-pub(crate) trait SynchronizerFactory: Send + Sync {
+pub trait SynchronizerFactory: Send + Sync {
+    /// Builds a new synchronizer instance.
     fn create(&self) -> Box<dyn Synchronizer>;
 
     /// Whether this factory builds the FDv1 fallback synchronizer.

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -4,7 +4,7 @@ pub mod model;
 pub mod polling;
 mod protocol;
 pub mod request_headers;
-mod source;
+pub mod source;
 pub mod streaming;
 mod url;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -3,7 +3,7 @@ pub mod fdv1_adapter;
 pub mod model;
 pub mod polling;
 mod protocol;
-mod request_headers;
+pub mod request_headers;
 mod source;
 pub mod streaming;
 mod url;

--- a/launchdarkly-server-sdk/src/fdv2/mod.rs
+++ b/launchdarkly-server-sdk/src/fdv2/mod.rs
@@ -1,10 +1,10 @@
-mod data_system;
-mod fdv1_adapter;
+pub mod data_system;
+pub mod fdv1_adapter;
 pub mod model;
-mod polling;
+pub mod polling;
 mod protocol;
 mod request_headers;
 mod source;
-mod streaming;
+pub mod streaming;
 mod url;
 mod wire;

--- a/launchdarkly-server-sdk/src/fdv2/model.rs
+++ b/launchdarkly-server-sdk/src/fdv2/model.rs
@@ -5,12 +5,17 @@ use crate::stores::store_types::StorageItem;
 
 use super::wire::{DeleteObject, PutObject};
 
-pub(crate) type Selector = Option<String>;
+/// Identifies a point in the flag-data stream, echoed back to request the next changes.
+pub type Selector = Option<String>;
 
+/// Whether a change set is a full payload, an incremental update, or carries no changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ChangeSetKind {
+pub enum ChangeSetKind {
+    /// The change set carries no changes.
     None,
+    /// The change set is a complete payload that replaces all data.
     Full,
+    /// The change set is an incremental update to existing data.
     Partial,
 }
 

--- a/launchdarkly-server-sdk/src/fdv2/polling.rs
+++ b/launchdarkly-server-sdk/src/fdv2/polling.rs
@@ -6,12 +6,13 @@ use http::{Request, Response, StatusCode};
 use launchdarkly_sdk_transport::{ByteStream, HttpTransport};
 use serde::Deserialize;
 
+use super::data_system::{InitializerFactory, SynchronizerFactory};
 use super::model::{ChangeSetKind, Selector};
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::request_headers::RequestHeaders;
 use super::source::{
     read_fallback_directive, ErrorInfo, ErrorKind, FDv1FallbackDirective, FDv2SourceEvent,
-    FDv2SourceResult,
+    FDv2SourceResult, Initializer, Synchronizer,
 };
 use super::url::build_fdv2_url;
 use crate::reqwest::is_http_error_recoverable;
@@ -287,6 +288,73 @@ impl<T: HttpTransport> super::source::Synchronizer for PollingSynchronizer<T> {
 
     fn name(&self) -> &str {
         "FDv2 polling synchronizer"
+    }
+}
+
+/// Builds a fresh `PollingInitializer` each time an initializer run starts.
+pub(crate) struct PollingInitializerFactory<T> {
+    transport: T,
+    base_url: String,
+    headers: RequestHeaders,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> PollingInitializerFactory<T> {
+    pub(crate) fn new(transport: T, base_url: String, headers: RequestHeaders) -> Self {
+        Self {
+            transport,
+            base_url,
+            headers,
+        }
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> InitializerFactory
+    for PollingInitializerFactory<T>
+{
+    fn create(&self) -> Box<dyn Initializer> {
+        Box::new(PollingInitializer::new(
+            self.transport.clone(),
+            self.base_url.clone(),
+            self.headers.clone(),
+            None,
+        ))
+    }
+}
+
+/// Builds a fresh `PollingSynchronizer` each time the synchronizer activates.
+pub(crate) struct PollingSynchronizerFactory<T> {
+    transport: T,
+    base_url: String,
+    headers: RequestHeaders,
+    poll_interval: Duration,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> PollingSynchronizerFactory<T> {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        headers: RequestHeaders,
+        poll_interval: Duration,
+    ) -> Self {
+        Self {
+            transport,
+            base_url,
+            headers,
+            poll_interval,
+        }
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> SynchronizerFactory
+    for PollingSynchronizerFactory<T>
+{
+    fn create(&self) -> Box<dyn Synchronizer> {
+        Box::new(PollingSynchronizer::new(
+            self.transport.clone(),
+            self.base_url.clone(),
+            self.headers.clone(),
+            self.poll_interval,
+        ))
     }
 }
 

--- a/launchdarkly-server-sdk/src/fdv2/request_headers.rs
+++ b/launchdarkly-server-sdk/src/fdv2/request_headers.rs
@@ -1,6 +1,6 @@
 /// The HTTP headers attached to every FDv2 request.
 #[derive(Clone)]
-pub(crate) struct RequestHeaders {
+pub struct RequestHeaders {
     headers: Vec<(&'static str, String)>,
 }
 
@@ -20,7 +20,8 @@ impl RequestHeaders {
         Self { headers }
     }
 
-    pub(super) fn iter(&self) -> impl Iterator<Item = (&'static str, &str)> + '_ {
+    /// Iterates the header name/value pairs to attach to a request.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, &str)> + '_ {
         self.headers
             .iter()
             .map(|(name, value)| (*name, value.as_str()))

--- a/launchdarkly-server-sdk/src/fdv2/source.rs
+++ b/launchdarkly-server-sdk/src/fdv2/source.rs
@@ -13,24 +13,36 @@ const DEFAULT_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 /// The longest server-supplied fallback TTL that is honored; longer values fall back to the default.
 const MAX_FALLBACK_TTL: Duration = Duration::from_secs(60 * 60);
 
+/// Classifies why a data source is interrupted or has failed.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ErrorKind {
+pub enum ErrorKind {
+    /// The cause is not one of the more specific kinds.
     Unknown,
+    /// The request failed at the network layer.
     NetworkError,
-    ErrorResponse { status_code: u16 },
+    /// The server returned an error status code.
+    ErrorResponse {
+        /// The HTTP status code.
+        status_code: u16,
+    },
+    /// The response could not be parsed.
     InvalidData,
 }
 
+/// Describes an error surfaced by a data source.
 #[derive(Debug, Clone)]
-pub(crate) struct ErrorInfo {
-    #[allow(dead_code)] // Will be read by data source status provider, once implemented.
-    pub(crate) kind: ErrorKind,
-    pub(crate) message: String,
+pub struct ErrorInfo {
+    /// The kind of error.
+    pub kind: ErrorKind,
+    /// A human-readable description.
+    pub message: String,
 }
 
+/// An instruction from LaunchDarkly to fall back to the FDv1 protocol.
 #[derive(Debug, Clone)]
-pub(crate) struct FDv1FallbackDirective {
-    pub(crate) ttl: Duration,
+pub struct FDv1FallbackDirective {
+    /// How long to stay on FDv1 before retrying FDv2.
+    pub ttl: Duration,
 }
 
 impl FDv1FallbackDirective {
@@ -66,27 +78,41 @@ pub(super) fn read_fallback_directive<'a>(
     Some(FDv1FallbackDirective::from_ttl(ttl))
 }
 
+/// The outcome of a single data source poll or stream read.
 #[derive(Debug)]
-pub(crate) enum FDv2SourceResult {
+pub enum FDv2SourceResult {
+    /// A set of flag and segment changes.
     ChangeSet(ChangeSet),
+    /// A transient failure; the source may recover.
     Interrupted(ErrorInfo),
+    /// An unrecoverable failure; the source is done.
     TerminalError(ErrorInfo),
+    /// The server asked the source to disconnect.
     Goodbye,
 }
 
+/// A source result paired with any FDv1 fallback directive seen on the same response.
 #[derive(Debug)]
-pub(crate) struct FDv2SourceEvent {
-    pub(crate) result: FDv2SourceResult,
-    pub(crate) fdv1_fallback: Option<FDv1FallbackDirective>,
+pub struct FDv2SourceEvent {
+    /// The source result.
+    pub result: FDv2SourceResult,
+    /// Present when the response carried an FDv1 fallback directive.
+    pub fdv1_fallback: Option<FDv1FallbackDirective>,
 }
 
-pub(crate) trait Initializer: Send {
+/// A data source that can obtain an initial payload.
+pub trait Initializer: Send {
+    /// Runs once to obtain an initial payload.
     fn run(&mut self) -> BoxFuture<'_, FDv2SourceEvent>;
+    /// The name used in logs.
     fn name(&self) -> &str;
 }
 
-pub(crate) trait Synchronizer: Send {
+/// A data source that keeps flag data up to date.
+pub trait Synchronizer: Send {
+    /// Fetches the next batch of changes after the given selector.
     fn next(&mut self, selector: Selector) -> BoxFuture<'_, FDv2SourceEvent>;
+    /// The name used in logs.
     fn name(&self) -> &str;
 }
 

--- a/launchdarkly-server-sdk/src/fdv2/streaming.rs
+++ b/launchdarkly-server-sdk/src/fdv2/streaming.rs
@@ -10,6 +10,7 @@ use http::Uri;
 use launchdarkly_sdk_transport::HttpTransport;
 use tokio::sync::watch;
 
+use super::data_system::SynchronizerFactory;
 use super::model::Selector;
 use super::protocol::{FDv2ProtocolHandler, ProtocolError, ProtocolResult};
 use super::request_headers::RequestHeaders;
@@ -290,6 +291,43 @@ impl<T: HttpTransport + Clone + Send + Sync + 'static> Synchronizer for Streamin
 
     fn name(&self) -> &str {
         "FDv2 streaming synchronizer"
+    }
+}
+
+/// Builds a fresh `StreamingSynchronizer` each time the synchronizer activates.
+pub(crate) struct StreamingSynchronizerFactory<T: HttpTransport + Clone + Send + Sync + 'static> {
+    transport: T,
+    base_url: String,
+    headers: RequestHeaders,
+    initial_reconnect_delay: Duration,
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> StreamingSynchronizerFactory<T> {
+    pub(crate) fn new(
+        transport: T,
+        base_url: String,
+        headers: RequestHeaders,
+        initial_reconnect_delay: Duration,
+    ) -> Self {
+        Self {
+            transport,
+            base_url,
+            headers,
+            initial_reconnect_delay,
+        }
+    }
+}
+
+impl<T: HttpTransport + Clone + Send + Sync + 'static> SynchronizerFactory
+    for StreamingSynchronizerFactory<T>
+{
+    fn create(&self) -> Box<dyn Synchronizer> {
+        Box::new(StreamingSynchronizer::new(
+            self.transport.clone(),
+            self.base_url.clone(),
+            self.headers.clone(),
+            self.initial_reconnect_delay,
+        ))
     }
 }
 

--- a/launchdarkly-server-sdk/src/fdv2/wire.rs
+++ b/launchdarkly-server-sdk/src/fdv2/wire.rs
@@ -18,14 +18,19 @@ pub(super) struct ServerIntent {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct ServerIntentPayload {
+    // Parsed from the wire but not used; only intent_code is read.
+    #[allow(dead_code)]
     pub(super) id: String,
+    #[allow(dead_code)]
     pub(super) target: u64,
     pub(super) intent_code: IntentCode,
+    #[allow(dead_code)]
     pub(super) reason: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub(super) struct PutObject {
+    #[allow(dead_code)] // Parsed from the wire but not used.
     pub(super) version: u64,
     pub(super) kind: String,
     pub(super) key: String,

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -61,6 +61,7 @@ mod client;
 mod config;
 mod data_source;
 mod data_source_builders;
+pub mod data_sources;
 mod data_system;
 mod data_system_builders;
 mod evaluation;

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -32,6 +32,9 @@ pub use config::{ApplicationInfo, BuildError as ConfigBuildError, Config, Config
 pub use data_source_builders::{
     BuildError as DataSourceBuildError, PollingDataSourceBuilder, StreamingDataSourceBuilder,
 };
+pub use data_system_builders::{
+    BuildError as DataSystemBuildError, DataSystemBuilder, FDv2PollingBuilder, FDv2StreamingBuilder,
+};
 pub use evaluation::{FlagDetail, FlagDetailConfig, FlagFilter};
 pub use events::event::MigrationOpEvent;
 pub use events::processor::EventProcessor;
@@ -59,9 +62,10 @@ mod config;
 mod data_source;
 mod data_source_builders;
 mod data_system;
+mod data_system_builders;
 mod evaluation;
 mod events;
-#[allow(dead_code)] // Tested but not yet reachable from production code.
+#[allow(dead_code)] // Some items are consumed only by later data-system phases.
 mod fdv2;
 mod feature_requester;
 mod feature_requester_builders;

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -65,7 +65,6 @@ mod data_system;
 mod data_system_builders;
 mod evaluation;
 mod events;
-#[allow(dead_code)] // Some items are consumed only by later data-system phases.
 mod fdv2;
 mod feature_requester;
 mod feature_requester_builders;

--- a/launchdarkly-server-sdk/src/stores/change_set.rs
+++ b/launchdarkly-server-sdk/src/stores/change_set.rs
@@ -4,21 +4,32 @@ use crate::fdv2::model::{ChangeSetKind, Selector};
 
 use super::store_types::StorageItem;
 
+/// A single flag or segment change within a change set.
 #[derive(Debug)]
-pub(crate) enum ItemChange {
+pub enum ItemChange {
+    /// A flag was upserted or deleted.
     Flag {
+        /// The flag key.
         key: String,
+        /// The new flag value or a tombstone.
         item: StorageItem<Flag>,
     },
+    /// A segment was upserted or deleted.
     Segment {
+        /// The segment key.
         key: String,
+        /// The new segment value or a tombstone.
         item: StorageItem<Segment>,
     },
 }
 
+/// A batch of flag and segment changes delivered by a data source.
 #[derive(Debug)]
-pub(crate) struct ChangeSet {
-    pub(crate) kind: ChangeSetKind,
-    pub(crate) changes: Vec<ItemChange>,
-    pub(crate) selector: Selector,
+pub struct ChangeSet {
+    /// Whether this is a full payload, an incremental update, or empty.
+    pub kind: ChangeSetKind,
+    /// The individual item changes.
+    pub changes: Vec<ItemChange>,
+    /// The selector to echo back on the next request.
+    pub selector: Selector,
 }


### PR DESCRIPTION
## Summary

Adds the public API for configuring an FDv2 data system and selecting it over the FDv1 data source.

- `ConfigBuilder::data_system` takes a `DataSystemBuilder` and, when set, supersedes the FDv1 `data_source`. It is ignored in offline or daemon mode.
- `DataSystemBuilder::default()` provides the recommended setup, while `custom()` lets the caller assemble the sources and FDv1 fallback explicitly and tune the fallback and recovery timeouts.
- `FDv2StreamingBuilder` and `FDv2PollingBuilder` configure individual sources, each with a `base_url` override.

The builders are public, while the factory and per-source configuration traits behind them stay internal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds an optional **FDv2 data system** path on `ConfigBuilder::data_system`, wired through `Client` startup so a configured `DataSystemBuilder` **replaces** the legacy FDv1 `data_source` (with warnings and a null data source when both are set). Offline and daemon mode still drop custom data-system config like they do for custom data sources.
> 
> Introduces **`data_system_builders`** with `DataSystemBuilder` (`custom()` vs `default()` recommended stack: poll initializer, stream + poll synchronizers, FDv1 polling fallback), plus `FDv2StreamingBuilder` and `FDv2PollingBuilder` for URL/transport/reconnect tuning. Factory wiring builds `FDv2DataSystem`, optionally wrapping an FDv1 fallback via `FDv1AdapterFactory`.
> 
> Exposes an experimental **`data_sources`** module and widens visibility on FDv2 traits/types (`Initializer`/`Synchronizer`, `ChangeSet`, errors, headers) so custom sources can be implemented; adds polling/streaming **factory** types to instantiate sources per orchestrator run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c20fc8c5de1841f4ffe14c4435ec01ae790cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->